### PR TITLE
Adding a GitHub action to install a Gazebo release in an appropriate linux distribution 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - name: 'Install Gazebo Garden in Linux runner'
+      - name: 'Install Gazebo Harmonic in Linux runner'
         uses: ./
         with:
-          required-gazebo-distributions: garden
+          required-gazebo-distributions: harmonic
       - name: 'Check Gazebo installation'
         run: gz sim --versions
   test_linux_fortress_garden:
@@ -46,9 +46,9 @@ jobs:
           - ubuntu:22.04
     steps:
       - uses: actions/checkout@v4
-      - name: 'Install Gazebo Harmonic in Linux runners'
+      - name: 'Install Gazebo Garden in Linux runners'
         uses: ./
         with:
-          required-gazebo-distributions: harmonic
+          required-gazebo-distributions: garden
       - name: 'Check Gazebo installation'
         run: gz sim --versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,5 +14,7 @@ jobs:
           - ubuntu:22.04
     steps:
       - uses: actions/checkout@v4
-      - name: 'Linux setup'
-        uses: ./
+      - uses: ./
+        # with:
+        #   required-gazebo-distributions: garden
+      - run: gz sim --versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: 'Test setup-gazebo'
 on:
-  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "releases/*"
+  schedule:
+    # Run the CI automatically twice per day to look for flakyness.
+    - cron: "0 */12 * * *"
 jobs:
   test_gazebo_install_ubuntu:
     name: 'Check installation of Gazebo on Ubuntu'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,39 @@ name: 'Test setup-gazebo'
 on:
   workflow_dispatch:
 jobs:
-  test_linux:
+  test_linux_citadel:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Install Gazebo Citadel in Linux runner'
+        uses: ./
+        with:
+          required-gazebo-distributions: citadel
+      - name: 'Check Gazebo installation'
+        run: gz sim --versions
+  test_linux_fortress_garden:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        gazebo_distribution:
+          - fortress
+          - garden
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Install Gazebo in Linux runner'
+        uses: ./
+        with:
+          required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
+      - name: 'Check Gazebo installation'
+        run: gz sim --versions
+  test_linux_harmonic:
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.docker_image }}
@@ -14,8 +46,9 @@ jobs:
           - ubuntu:22.04
     steps:
       - uses: actions/checkout@v4
-      - name: 'Install Gazebo in Linux runner'
+      - name: 'Install Gazebo Harmonic in Linux runners'
         uses: ./
         with:
-          required-gazebo-distributions: garden
-      - run: gz sim --versions
+          required-gazebo-distributions: harmonic
+      - name: 'Check Gazebo installation'
+        run: gz sim --versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,6 @@ jobs:
           - ubuntu:20.04
           - ubuntu:22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: 'Linux setup'
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: 'Test setup-gazebo'
 on:
   workflow_dispatch:
 jobs:
-  test_linux_citadel:
+  test_linux_harmonic:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:20.04
+      image: ubuntu:22.04
     strategy:
       fail-fast: false
     steps:
@@ -16,7 +16,7 @@ jobs:
           required-gazebo-distributions: harmonic
       - name: 'Check Gazebo installation'
         run: gz sim --versions
-  test_linux_fortress_garden:
+  test_linux_citadel_fortress:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:20.04
@@ -34,7 +34,7 @@ jobs:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
       - name: 'Check Gazebo installation'
         run: ign gazebo --versions
-  test_linux_harmonic:
+  test_linux_garden:
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.docker_image }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,31 +19,34 @@ jobs:
           # Gazebo Citadel (Dec 2019 - Dec 2024)
           - docker_image: ubuntu:focal
             gazebo_distribution: citadel
-            gazebo_version: ign
 
           # Gazebo Fortress (Sep 2021 - Sep 2026)
           - docker_image: ubuntu:focal
             gazebo_distribution: fortress
-            gazebo_version: ign
 
           # Gazebo Garden (Sep 2022 - Nov 2024)
           - docker_image: ubuntu:focal
             gazebo_distribution: garden
-            gazebo_version: gz
 
           # Gazebo Harmonic (Sep 2023 - Sep 2028)
           - docker_image: ubuntu:jammy
             gazebo_distribution: harmonic
-            gazebo_version: gz
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: "20.x"
-      - uses: ./
+      - name: 'Check Gazebo installation on Ubuntu runner'
+        uses: ./
         with:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
-      - run: ign gazebo --versions
-        if: matrix.gazebo_version == 'ign'
-      - run: gz sim --versions
-        if: matrix.gazebo_version == 'gz'
+      - name: 'Test Gazebo installation'
+        run: |
+          if command -v ign > /dev/null; then
+            ign gazebo --versions
+          elif command -v gz > /dev/null; then
+            gz sim --versions
+          else
+            echo "Neither ign nor gz command found"
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,8 @@ jobs:
           - ubuntu:22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: ./
-        # with:
-        #   required-gazebo-distributions: garden
+      - name: 'Install Gazebo in Linux runner'
+        uses: ./
+        with:
+          required-gazebo-distributions: garden
       - run: gz sim --versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,53 +2,48 @@ name: 'Test setup-gazebo'
 on:
   workflow_dispatch:
 jobs:
-  test_linux_harmonic:
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:22.04
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
-      - name: 'Install Gazebo Harmonic in Linux runner'
-        uses: ./
-        with:
-          required-gazebo-distributions: harmonic
-      - name: 'Check Gazebo installation'
-        run: gz sim --versions
-  test_linux_citadel_fortress:
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        gazebo_distribution:
-          - citadel
-          - fortress
-    steps:
-      - uses: actions/checkout@v4
-      - name: 'Install Gazebo in Linux runners'
-        uses: ./
-        with:
-          required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
-      - name: 'Check Gazebo installation'
-        run: ign gazebo --versions
-  test_linux_garden:
+  test_gazebo_install_ubuntu:
+    name: 'Check installation of Gazebo on Ubuntu'
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.docker_image }}
     strategy:
       fail-fast: false
       matrix:
-        docker_image:
-          - ubuntu:20.04
-          - ubuntu:22.04
+        gazebo_distribution:
+          - citadel
+          - fortress
+          - garden
+          - harmonic
+        include:
+          # Gazebo Citadel (Dec 2019 - Dec 2024)
+          - docker_image: ubuntu:focal
+            gazebo_distribution: citadel
+            gazebo_version: ign
+
+          # Gazebo Fortress (Sep 2021 - Sep 2026)
+          - docker_image: ubuntu:focal
+            gazebo_distribution: fortress
+            gazebo_version: ign
+
+          # Gazebo Garden (Sep 2022 - Nov 2024)
+          - docker_image: ubuntu:focal
+            gazebo_distribution: garden
+            gazebo_version: gz
+
+          # Gazebo Harmonic (Sep 2023 - Sep 2028)
+          - docker_image: ubuntu:jammy
+            gazebo_distribution: harmonic
+            gazebo_version: gz
     steps:
       - uses: actions/checkout@v4
-      - name: 'Install Gazebo Garden in Linux runners'
-        uses: ./
+      - uses: actions/setup-node@v4.0.2
         with:
-          required-gazebo-distributions: garden
-      - name: 'Check Gazebo installation'
-        run: gz sim --versions
+          node-version: "20.x"
+      - uses: ./
+        with:
+          required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
+      - run: ign gazebo --versions
+        if: matrix.gazebo_version == 'ign'
+      - run: gz sim --versions
+        if: matrix.gazebo_version == 'gz'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - name: 'Install Gazebo Citadel in Linux runner'
+      - name: 'Install Gazebo Garden in Linux runner'
         uses: ./
         with:
-          required-gazebo-distributions: citadel
+          required-gazebo-distributions: garden
       - name: 'Check Gazebo installation'
         run: gz sim --versions
   test_linux_fortress_garden:
@@ -24,16 +24,16 @@ jobs:
       fail-fast: false
       matrix:
         gazebo_distribution:
+          - citadel
           - fortress
-          - garden
     steps:
       - uses: actions/checkout@v4
-      - name: 'Install Gazebo in Linux runner'
+      - name: 'Install Gazebo in Linux runners'
         uses: ./
         with:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
       - name: 'Check Gazebo installation'
-        run: gz sim --versions
+        run: ign gazebo --versions
   test_linux_harmonic:
     runs-on: ubuntu-latest
     container:

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,19 @@
 name: 'Setup Gazebo release'
 description: |
   Install a Gazebo release on a Linux system
+required-gazebo-distributions:
+    description: |
+      List of Gazebo distributions to be installed.
+
+      Allowed Gazebo distributions
+      - citadel
+      - fortress
+      - garden
+      - harmonic
+
+      Multiple values can be passed using a whitespace delimited list
+      "fortress garden".
+    required: true
 runs:
   using: node20
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,8 @@ required-gazebo-distributions:
 
       Multiple values can be passed using a whitespace delimited list
       "fortress garden".
-    required: true
+    required: false
+    default: ''
 runs:
   using: node20
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -26495,7 +26495,7 @@ function determineDistribCodename() {
 }
 exports.determineDistribCodename = determineDistribCodename;
 // List of valid Gazebo distributions
-const validDistro = ["citadel", "fortress", "garden", "humble"];
+const validDistro = ["citadel", "fortress", "garden", "harmonic"];
 /**
  * Validate all Gazebo input distribution names
  *

--- a/dist/index.js
+++ b/dist/index.js
@@ -26256,12 +26256,58 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.runLinux = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const io = __importStar(__nccwpck_require__(7436));
 const apt = __importStar(__nccwpck_require__(4671));
 const utils = __importStar(__nccwpck_require__(1314));
+const path = __importStar(__nccwpck_require__(1017));
+const fs_1 = __importDefault(__nccwpck_require__(7147));
+// Open Robotics APT Repository public GPG key, as retrieved by
+//
+// $ apt-key adv --refresh-keys --keyserver hkp://keyserver.ubuntu.com:80 \
+//     C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+// See also http://packages.ros.org/ros.asc (caution, this is an HTTP URL)
+//
+// Unfortunately, usin apt-key adv is slow, and is failing sometimes, causing
+// spurious pipelines failures. The action is hard-coding the key here to
+// mitigate this issue.
+const openRoboticsAptPublicGpgKey = `
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v1
+
+mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+/SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQgA
+PgIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgBYhBMHPbjHmut6IaLFytPQu1vur
+F8ZUBQJgsdhRBQkLTMW7AAoJEPQu1vurF8ZUTMwP/3f7EkOPIFjUdRmpNJ2db4iB
+RQu5b2SJRG+KIdbvQBzKUBMV6/RUhEDPjhXZI3zDevzBewvAMKkqs2Q1cWo9WV7Z
+PyTkvSyey/Tjn+PozcdvzkvrEjDMftIk8E1WzLGq7vnPLZ1q/b6Vq4H373Z+EDWa
+DaDwW72CbCBLWAVtqff80CwlI2x8fYHKr3VBUnwcXNHR4+nRABfAWnaU4k+oTshC
+Qucsd8vitNfsSXrKuKyz91IRHRPnJjx8UvGU4tRGfrHkw1505EZvgP02vXeRyWBR
+fKiL1vGy4tCSRDdZO3ms2J2m08VPv65HsHaWYMnO+rNJmMZj9d9JdL/9GRf5F6U0
+quoIFL39BhUEvBynuqlrqistnyOhw8W/IQy/ymNzBMcMz6rcMjMwhkgm/LNXoSD1
+1OrJu4ktQwRhwvGVarnB8ihwjsTxZFylaLmFSfaA+OAlOqCLS1OkIVMzjW+Ul6A6
+qjiCEUOsnlf4CGlhzNMZOx3low6ixzEqKOcfECpeIj80a2fBDmWkcAAjlHu6VBhA
+TUDG9e2xKLzV2Z/DLYsb3+n9QW7KO0yZKfiuUo6AYboAioQKn5jh3iRvjGh2Ujpo
+22G+oae3PcCc7G+z12j6xIY709FQuA49dA2YpzMda0/OX4LP56STEveDRrO+CnV6
+WE+F5FaIKwb72PL4rLi4
+=i0tj
+-----END PGP PUBLIC KEY BLOCK-----
+`;
 /**
  * Configure basic OS stuff.
  */
@@ -26302,11 +26348,44 @@ function configOs() {
     });
 }
 /**
+ * Add OSRF APT repository key.
+ *
+ * This is necessary even when building from source to install colcon, vcs, etc.
+ */
+function addAptRepoKey() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const workspace = process.env.GITHUB_WORKSPACE;
+        const keyFilePath = path.join(workspace, "gazebo.key");
+        fs_1.default.writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
+        yield utils.exec("sudo", ["apt-key", "add", keyFilePath]);
+    });
+}
+/**
+ * Add OSRF APT repository.
+ *
+ * @param ubuntuCodename the Ubuntu version codename
+ */
+function addAptRepo(ubuntuCodename) {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield utils.exec("sudo", [
+            "bash",
+            "-c",
+            `echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" > /etc/apt/sources.list.d/gazebo-stable.list`,
+        ]);
+        yield utils.exec("sudo", ["apt-get", "update"]);
+    });
+}
+/**
  * Install Gazebo on a Linux worker.
  */
 function runLinux() {
     return __awaiter(this, void 0, void 0, function* () {
         yield configOs();
+        yield addAptRepoKey();
+        const ubuntuCodename = yield utils.determineDistribCodename();
+        yield addAptRepo(ubuntuCodename);
+        // Only there to test the installation of a gazebo. To be removed later
+        yield utils.exec("sudo", ["apt-get", "install", "gz-garden"]);
     });
 }
 exports.runLinux = runLinux;

--- a/dist/index.js
+++ b/dist/index.js
@@ -26285,7 +26285,7 @@ function configOs() {
         yield utils.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
         yield utils.exec("sudo", ["apt-get", "update"]);
         // Install tools required to configure the worker system.
-        yield apt.runAptGetInstall(["wget", "curl", "gnupg2", "locales", "lsb-release"]);
+        yield apt.runAptGetInstall(["wget", "curl", "gnupg2", "locales", "lsb-release", "ca-certificates"]);
         // Select a locale supporting Unicode.
         yield utils.exec("sudo", ["locale-gen", "en_US", "en_US.UTF-8"]);
         core.exportVariable("LANG", "en_US.UTF-8");

--- a/dist/index.js
+++ b/dist/index.js
@@ -26311,8 +26311,8 @@ function addAptRepoKey() {
         yield utils.exec("sudo", [
             "bash",
             "-c",
-            `wget --no-check-certificate https://packages.osrfoundation.org/gazebo.gpg -O
-    /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg`
+            `wget --no-check-certificate https://packages.osrfoundation.org/gazebo.gpg -O \
+    /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg`,
         ]);
     });
 }
@@ -26326,8 +26326,8 @@ function addAptRepo(ubuntuCodename) {
         yield utils.exec("sudo", [
             "bash",
             "-c",
-            `echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg]
-    http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" |
+            `echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] \
+    http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" | \
     sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
         ]);
         yield utils.exec("sudo", ["apt-get", "update"]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -26311,7 +26311,8 @@ function addAptRepoKey() {
         yield utils.exec("sudo", [
             "bash",
             "-c",
-            "wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg"
+            `wget --no-check-certificate https://packages.osrfoundation.org/gazebo.gpg -O
+    /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg`
         ]);
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -26448,7 +26448,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.determineDistribCodename = exports.exec = void 0;
+exports.getRequiredGazeboDistributions = exports.validateDistro = exports.determineDistribCodename = exports.exec = void 0;
 const actions_exec = __importStar(__nccwpck_require__(1514));
 const core = __importStar(__nccwpck_require__(2186));
 /**
@@ -26492,6 +26492,42 @@ function determineDistribCodename() {
     });
 }
 exports.determineDistribCodename = determineDistribCodename;
+// List of valid Gazebo distributions
+const validDistro = ["citadel", "fortress", "garden", "humble"];
+//.
+/**
+ * Validate all Gazebo input distribution names
+ *
+ * @param requiredGazeboDistributionsList
+ * @returns boolean
+ */
+function validateDistro(requiredGazeboDistributionsList) {
+    for (const gazeboDistro of requiredGazeboDistributionsList) {
+        if (validDistro.indexOf(gazeboDistro) <= -1) {
+            return false;
+        }
+    }
+    return true;
+}
+exports.validateDistro = validateDistro;
+/**
+ * Gets the input of the Gazebo distributions to be installed and
+ * validates them
+ *
+ * @returns string[] List of validated Gazebo distributions
+ */
+function getRequiredGazeboDistributions() {
+    let requiredGazeboDistributionsList = [];
+    const requiredGazeboDistributions = core.getInput("required-gazebo-distributions");
+    if (requiredGazeboDistributions) {
+        requiredGazeboDistributionsList = requiredGazeboDistributions.split(RegExp("\\s"));
+    }
+    if (!validateDistro(requiredGazeboDistributionsList)) {
+        throw new Error("Input has invalid distribution names.");
+    }
+    return requiredGazeboDistributionsList;
+}
+exports.getRequiredGazeboDistributions = getRequiredGazeboDistributions;
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -26355,7 +26355,7 @@ function configOs() {
 function addAptRepoKey() {
     return __awaiter(this, void 0, void 0, function* () {
         const workspace = process.env.GITHUB_WORKSPACE;
-        const keyFilePath = path.join(workspace, "gazebo.key");
+        const keyFilePath = path.join(workspace, "/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg");
         fs_1.default.writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
         yield utils.exec("sudo", ["apt-key", "add", keyFilePath]);
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -26523,6 +26523,9 @@ function getRequiredGazeboDistributions() {
     if (requiredGazeboDistributions) {
         requiredGazeboDistributionsList = requiredGazeboDistributions.split(RegExp("\\s"));
     }
+    else {
+        throw new Error("Input cannot be empty.");
+    }
     if (!validateDistro(requiredGazeboDistributionsList)) {
         throw new Error("Input has invalid distribution names.");
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -26340,10 +26340,12 @@ function runLinux() {
     return __awaiter(this, void 0, void 0, function* () {
         yield configOs();
         yield addAptRepoKey();
+        // Add repo according to Ubuntu version
         const ubuntuCodename = yield utils.determineDistribCodename();
         yield addAptRepo(ubuntuCodename);
-        // Only there to test the installation of a gazebo. To be removed later
-        yield apt.runAptGetInstall(['gz-garden',]);
+        for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
+            yield apt.runAptGetInstall([`gz-${gazeboDistro}`]);
+        }
     });
 }
 exports.runLinux = runLinux;
@@ -26494,12 +26496,11 @@ function determineDistribCodename() {
 exports.determineDistribCodename = determineDistribCodename;
 // List of valid Gazebo distributions
 const validDistro = ["citadel", "fortress", "garden", "humble"];
-//.
 /**
  * Validate all Gazebo input distribution names
  *
  * @param requiredGazeboDistributionsList
- * @returns boolean
+ * @returns boolean Validity of Gazebo distribution
  */
 function validateDistro(requiredGazeboDistributionsList) {
     for (const gazeboDistro of requiredGazeboDistributionsList) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -26189,7 +26189,6 @@ exports.runAptGetInstall = void 0;
 const utils = __importStar(__nccwpck_require__(1314));
 const aptCommandLine = [
     "DEBIAN_FRONTEND=noninteractive",
-    "RTI_NC_LICENSE_ACCEPTED=yes",
     "apt-get",
     "install",
     "--no-install-recommends",
@@ -26311,7 +26310,7 @@ function addAptRepoKey() {
         yield utils.exec("sudo", [
             "bash",
             "-c",
-            `wget --no-check-certificate https://packages.osrfoundation.org/gazebo.gpg -O \
+            `wget https://packages.osrfoundation.org/gazebo.gpg -O \
     /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg`,
         ]);
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -26256,58 +26256,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.runLinux = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const io = __importStar(__nccwpck_require__(7436));
 const apt = __importStar(__nccwpck_require__(4671));
 const utils = __importStar(__nccwpck_require__(1314));
-const path = __importStar(__nccwpck_require__(1017));
-const fs_1 = __importDefault(__nccwpck_require__(7147));
-// Open Robotics APT Repository public GPG key, as retrieved by
-//
-// $ apt-key adv --refresh-keys --keyserver hkp://keyserver.ubuntu.com:80 \
-//     C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-// See also http://packages.ros.org/ros.asc (caution, this is an HTTP URL)
-//
-// Unfortunately, usin apt-key adv is slow, and is failing sometimes, causing
-// spurious pipelines failures. The action is hard-coding the key here to
-// mitigate this issue.
-const openRoboticsAptPublicGpgKey = `
------BEGIN PGP PUBLIC KEY BLOCK-----
-Version: GnuPG v1
-
-mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
-VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
-u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
-K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
-aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
-TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
-pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
-V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
-hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
-/SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
-okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
-tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQgA
-PgIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgBYhBMHPbjHmut6IaLFytPQu1vur
-F8ZUBQJgsdhRBQkLTMW7AAoJEPQu1vurF8ZUTMwP/3f7EkOPIFjUdRmpNJ2db4iB
-RQu5b2SJRG+KIdbvQBzKUBMV6/RUhEDPjhXZI3zDevzBewvAMKkqs2Q1cWo9WV7Z
-PyTkvSyey/Tjn+PozcdvzkvrEjDMftIk8E1WzLGq7vnPLZ1q/b6Vq4H373Z+EDWa
-DaDwW72CbCBLWAVtqff80CwlI2x8fYHKr3VBUnwcXNHR4+nRABfAWnaU4k+oTshC
-Qucsd8vitNfsSXrKuKyz91IRHRPnJjx8UvGU4tRGfrHkw1505EZvgP02vXeRyWBR
-fKiL1vGy4tCSRDdZO3ms2J2m08VPv65HsHaWYMnO+rNJmMZj9d9JdL/9GRf5F6U0
-quoIFL39BhUEvBynuqlrqistnyOhw8W/IQy/ymNzBMcMz6rcMjMwhkgm/LNXoSD1
-1OrJu4ktQwRhwvGVarnB8ihwjsTxZFylaLmFSfaA+OAlOqCLS1OkIVMzjW+Ul6A6
-qjiCEUOsnlf4CGlhzNMZOx3low6ixzEqKOcfECpeIj80a2fBDmWkcAAjlHu6VBhA
-TUDG9e2xKLzV2Z/DLYsb3+n9QW7KO0yZKfiuUo6AYboAioQKn5jh3iRvjGh2Ujpo
-22G+oae3PcCc7G+z12j6xIY709FQuA49dA2YpzMda0/OX4LP56STEveDRrO+CnV6
-WE+F5FaIKwb72PL4rLi4
-=i0tj
------END PGP PUBLIC KEY BLOCK-----
-`;
 /**
  * Configure basic OS stuff.
  */
@@ -26332,7 +26286,7 @@ function configOs() {
         yield utils.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
         yield utils.exec("sudo", ["apt-get", "update"]);
         // Install tools required to configure the worker system.
-        yield apt.runAptGetInstall(["curl", "gnupg2", "locales", "lsb-release"]);
+        yield apt.runAptGetInstall(["wget", "curl", "gnupg2", "locales", "lsb-release"]);
         // Select a locale supporting Unicode.
         yield utils.exec("sudo", ["locale-gen", "en_US", "en_US.UTF-8"]);
         core.exportVariable("LANG", "en_US.UTF-8");
@@ -26354,10 +26308,11 @@ function configOs() {
  */
 function addAptRepoKey() {
     return __awaiter(this, void 0, void 0, function* () {
-        const workspace = process.env.GITHUB_WORKSPACE;
-        const keyFilePath = path.join(workspace, "/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg");
-        fs_1.default.writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
-        yield utils.exec("sudo", ["apt-key", "add", keyFilePath]);
+        yield utils.exec("sudo", [
+            "bash",
+            "-c",
+            "wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg"
+        ]);
     });
 }
 /**
@@ -26370,7 +26325,9 @@ function addAptRepo(ubuntuCodename) {
         yield utils.exec("sudo", [
             "bash",
             "-c",
-            `echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" > /etc/apt/sources.list.d/gazebo-stable.list`,
+            `echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg]
+    http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" |
+    sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
         ]);
         yield utils.exec("sudo", ["apt-get", "update"]);
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -26343,7 +26343,7 @@ function runLinux() {
         const ubuntuCodename = yield utils.determineDistribCodename();
         yield addAptRepo(ubuntuCodename);
         // Only there to test the installation of a gazebo. To be removed later
-        yield utils.exec("sudo", ["apt-get", "install", "gz-garden"]);
+        yield apt.runAptGetInstall(['gz-garden',]);
     });
 }
 exports.runLinux = runLinux;

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -2,7 +2,6 @@ import * as utils from "../utils";
 
 const aptCommandLine: string[] = [
   "DEBIAN_FRONTEND=noninteractive",
-  "RTI_NC_LICENSE_ACCEPTED=yes",
   "apt-get",
   "install",
   "--no-install-recommends",

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -1,13 +1,13 @@
 import * as utils from "../utils";
 
 const aptCommandLine: string[] = [
-	"DEBIAN_FRONTEND=noninteractive",
-	"RTI_NC_LICENSE_ACCEPTED=yes",
-	"apt-get",
-	"install",
-	"--no-install-recommends",
-	"--quiet",
-	"--yes",
+  "DEBIAN_FRONTEND=noninteractive",
+  "RTI_NC_LICENSE_ACCEPTED=yes",
+  "apt-get",
+  "install",
+  "--no-install-recommends",
+  "--quiet",
+  "--yes",
 ];
 
 /**
@@ -24,5 +24,5 @@ const aptCommandLine: string[] = [
  * @returns Promise<number> exit code
  */
 export async function runAptGetInstall(packages: string[]): Promise<number> {
-	return utils.exec("sudo", aptCommandLine.concat(packages));
+  return utils.exec("sudo", aptCommandLine.concat(packages));
 }

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -57,7 +57,8 @@ async function addAptRepoKey(): Promise<void> {
 	await utils.exec("sudo", [
     "bash",
     "-c",
-    "wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg"
+    `wget --no-check-certificate https://packages.osrfoundation.org/gazebo.gpg -O
+    /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg`
   ]);
 }
 

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -90,6 +90,6 @@ export async function runLinux(): Promise<void> {
 	await addAptRepo(ubuntuCodename);
 
   // Only there to test the installation of a gazebo. To be removed later
-  await utils.exec("sudo", ["apt-get", "install", "gz-garden"]);
+  await apt.runAptGetInstall(['gz-garden',]);
 
 }

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -8,41 +8,41 @@ import * as utils from "./utils";
  * Configure basic OS stuff.
  */
 async function configOs(): Promise<void> {
-	// When this action runs in a Docker image, sudo may be missing.
-	// This installs sudo to avoid having to handle both cases (action runs as
-	// root, action does not run as root) everywhere in the action.
-	try {
-		await io.which("sudo", true);
-	} catch (err) {
-		await utils.exec("apt-get", ["update"]);
-		await utils.exec("apt-get", [
-			"install",
-			"--no-install-recommends",
-			"--quiet",
-			"--yes",
-			"sudo",
-		]);
-	}
+  // When this action runs in a Docker image, sudo may be missing.
+  // This installs sudo to avoid having to handle both cases (action runs as
+  // root, action does not run as root) everywhere in the action.
+  try {
+    await io.which("sudo", true);
+  } catch (err) {
+    await utils.exec("apt-get", ["update"]);
+    await utils.exec("apt-get", [
+      "install",
+      "--no-install-recommends",
+      "--quiet",
+      "--yes",
+      "sudo",
+    ]);
+  }
 
-	await utils.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
-	await utils.exec("sudo", ["apt-get", "update"]);
+  await utils.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
+  await utils.exec("sudo", ["apt-get", "update"]);
 
-	// Install tools required to configure the worker system.
-	await apt.runAptGetInstall(["wget", "curl", "gnupg2", "locales", "lsb-release"]);
+  // Install tools required to configure the worker system.
+  await apt.runAptGetInstall(["wget", "curl", "gnupg2", "locales", "lsb-release"]);
 
-	// Select a locale supporting Unicode.
-	await utils.exec("sudo", ["locale-gen", "en_US", "en_US.UTF-8"]);
-	core.exportVariable("LANG", "en_US.UTF-8");
+  // Select a locale supporting Unicode.
+  await utils.exec("sudo", ["locale-gen", "en_US", "en_US.UTF-8"]);
+  core.exportVariable("LANG", "en_US.UTF-8");
 
-	// Enforce UTC time for consistency.
-	await utils.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
-	await utils.exec("sudo", [
-		"ln",
-		"-sf",
-		"/usr/share/zoneinfo/Etc/UTC",
-		"/etc/localtime",
-	]);
-	await apt.runAptGetInstall(["tzdata"]);
+  // Enforce UTC time for consistency.
+  await utils.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
+  await utils.exec("sudo", [
+    "ln",
+    "-sf",
+    "/usr/share/zoneinfo/Etc/UTC",
+    "/etc/localtime",
+  ]);
+  await apt.runAptGetInstall(["tzdata"]);
 }
 
 /**
@@ -51,10 +51,10 @@ async function configOs(): Promise<void> {
  * This is necessary even when building from source to install colcon, vcs, etc.
  */
 async function addAptRepoKey(): Promise<void> {
-	await utils.exec("sudo", [
+  await utils.exec("sudo", [
     "bash",
     "-c",
-    `wget --no-check-certificate https://packages.osrfoundation.org/gazebo.gpg -O \
+    `wget https://packages.osrfoundation.org/gazebo.gpg -O \
     /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg`,
   ]);
 }
@@ -72,21 +72,21 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
     http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" | \
     sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
   ]);
-	await utils.exec("sudo", ["apt-get", "update"]);
+  await utils.exec("sudo", ["apt-get", "update"]);
 }
 
 /**
  * Install Gazebo on a Linux worker.
  */
 export async function runLinux(): Promise<void> {
-	await configOs();
+  await configOs();
   await addAptRepoKey();
 
   // Add repo according to Ubuntu version
-	const ubuntuCodename = await utils.determineDistribCodename();
-	await addAptRepo(ubuntuCodename);
+  const ubuntuCodename = await utils.determineDistribCodename();
+  await addAptRepo(ubuntuCodename);
 
   for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
-		await apt.runAptGetInstall([`gz-${gazeboDistro}`]);
-	}
+    await apt.runAptGetInstall([`gz-${gazeboDistro}`]);
+  }
 }

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -7,48 +7,6 @@ import * as utils from "./utils";
 import * as path from "path";
 import fs from "fs";
 
-// Open Robotics APT Repository public GPG key, as retrieved by
-//
-// $ apt-key adv --refresh-keys --keyserver hkp://keyserver.ubuntu.com:80 \
-//     C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-// See also http://packages.ros.org/ros.asc (caution, this is an HTTP URL)
-//
-// Unfortunately, usin apt-key adv is slow, and is failing sometimes, causing
-// spurious pipelines failures. The action is hard-coding the key here to
-// mitigate this issue.
-const openRoboticsAptPublicGpgKey = `
------BEGIN PGP PUBLIC KEY BLOCK-----
-Version: GnuPG v1
-
-mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
-VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
-u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
-K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
-aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
-TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
-pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
-V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
-hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
-/SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
-okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
-tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQgA
-PgIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgBYhBMHPbjHmut6IaLFytPQu1vur
-F8ZUBQJgsdhRBQkLTMW7AAoJEPQu1vurF8ZUTMwP/3f7EkOPIFjUdRmpNJ2db4iB
-RQu5b2SJRG+KIdbvQBzKUBMV6/RUhEDPjhXZI3zDevzBewvAMKkqs2Q1cWo9WV7Z
-PyTkvSyey/Tjn+PozcdvzkvrEjDMftIk8E1WzLGq7vnPLZ1q/b6Vq4H373Z+EDWa
-DaDwW72CbCBLWAVtqff80CwlI2x8fYHKr3VBUnwcXNHR4+nRABfAWnaU4k+oTshC
-Qucsd8vitNfsSXrKuKyz91IRHRPnJjx8UvGU4tRGfrHkw1505EZvgP02vXeRyWBR
-fKiL1vGy4tCSRDdZO3ms2J2m08VPv65HsHaWYMnO+rNJmMZj9d9JdL/9GRf5F6U0
-quoIFL39BhUEvBynuqlrqistnyOhw8W/IQy/ymNzBMcMz6rcMjMwhkgm/LNXoSD1
-1OrJu4ktQwRhwvGVarnB8ihwjsTxZFylaLmFSfaA+OAlOqCLS1OkIVMzjW+Ul6A6
-qjiCEUOsnlf4CGlhzNMZOx3low6ixzEqKOcfECpeIj80a2fBDmWkcAAjlHu6VBhA
-TUDG9e2xKLzV2Z/DLYsb3+n9QW7KO0yZKfiuUo6AYboAioQKn5jh3iRvjGh2Ujpo
-22G+oae3PcCc7G+z12j6xIY709FQuA49dA2YpzMda0/OX4LP56STEveDRrO+CnV6
-WE+F5FaIKwb72PL4rLi4
-=i0tj
------END PGP PUBLIC KEY BLOCK-----
-`;
-
 /**
  * Configure basic OS stuff.
  */
@@ -73,7 +31,7 @@ async function configOs(): Promise<void> {
 	await utils.exec("sudo", ["apt-get", "update"]);
 
 	// Install tools required to configure the worker system.
-	await apt.runAptGetInstall(["curl", "gnupg2", "locales", "lsb-release"]);
+	await apt.runAptGetInstall(["wget", "curl", "gnupg2", "locales", "lsb-release"]);
 
 	// Select a locale supporting Unicode.
 	await utils.exec("sudo", ["locale-gen", "en_US", "en_US.UTF-8"]);
@@ -96,10 +54,11 @@ async function configOs(): Promise<void> {
  * This is necessary even when building from source to install colcon, vcs, etc.
  */
 async function addAptRepoKey(): Promise<void> {
-	const workspace = process.env.GITHUB_WORKSPACE as string;
-	const keyFilePath = path.join(workspace, "/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg");
-	fs.writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
-	await utils.exec("sudo", ["apt-key", "add", keyFilePath]);
+	await utils.exec("sudo", [
+    "bash",
+    "-c",
+    "wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg"
+  ]);
 }
 
 /**
@@ -111,7 +70,9 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
   await utils.exec("sudo", [
     "bash",
     "-c",
-    `echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" > /etc/apt/sources.list.d/gazebo-stable.list`,
+    `echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg]
+    http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" |
+    sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
   ]);
 
 	await utils.exec("sudo", ["apt-get", "update"]);

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -7,6 +7,48 @@ import * as utils from "./utils";
 import * as path from "path";
 import fs from "fs";
 
+// Open Robotics APT Repository public GPG key, as retrieved by
+//
+// $ apt-key adv --refresh-keys --keyserver hkp://keyserver.ubuntu.com:80 \
+//     C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+// See also http://packages.ros.org/ros.asc (caution, this is an HTTP URL)
+//
+// Unfortunately, usin apt-key adv is slow, and is failing sometimes, causing
+// spurious pipelines failures. The action is hard-coding the key here to
+// mitigate this issue.
+const openRoboticsAptPublicGpgKey = `
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v1
+
+mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+/SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQgA
+PgIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgBYhBMHPbjHmut6IaLFytPQu1vur
+F8ZUBQJgsdhRBQkLTMW7AAoJEPQu1vurF8ZUTMwP/3f7EkOPIFjUdRmpNJ2db4iB
+RQu5b2SJRG+KIdbvQBzKUBMV6/RUhEDPjhXZI3zDevzBewvAMKkqs2Q1cWo9WV7Z
+PyTkvSyey/Tjn+PozcdvzkvrEjDMftIk8E1WzLGq7vnPLZ1q/b6Vq4H373Z+EDWa
+DaDwW72CbCBLWAVtqff80CwlI2x8fYHKr3VBUnwcXNHR4+nRABfAWnaU4k+oTshC
+Qucsd8vitNfsSXrKuKyz91IRHRPnJjx8UvGU4tRGfrHkw1505EZvgP02vXeRyWBR
+fKiL1vGy4tCSRDdZO3ms2J2m08VPv65HsHaWYMnO+rNJmMZj9d9JdL/9GRf5F6U0
+quoIFL39BhUEvBynuqlrqistnyOhw8W/IQy/ymNzBMcMz6rcMjMwhkgm/LNXoSD1
+1OrJu4ktQwRhwvGVarnB8ihwjsTxZFylaLmFSfaA+OAlOqCLS1OkIVMzjW+Ul6A6
+qjiCEUOsnlf4CGlhzNMZOx3low6ixzEqKOcfECpeIj80a2fBDmWkcAAjlHu6VBhA
+TUDG9e2xKLzV2Z/DLYsb3+n9QW7KO0yZKfiuUo6AYboAioQKn5jh3iRvjGh2Ujpo
+22G+oae3PcCc7G+z12j6xIY709FQuA49dA2YpzMda0/OX4LP56STEveDRrO+CnV6
+WE+F5FaIKwb72PL4rLi4
+=i0tj
+-----END PGP PUBLIC KEY BLOCK-----
+`;
+
 /**
  * Configure basic OS stuff.
  */
@@ -49,10 +91,43 @@ async function configOs(): Promise<void> {
 }
 
 /**
+ * Add OSRF APT repository key.
+ *
+ * This is necessary even when building from source to install colcon, vcs, etc.
+ */
+async function addAptRepoKey(): Promise<void> {
+	const workspace = process.env.GITHUB_WORKSPACE as string;
+	const keyFilePath = path.join(workspace, "gazebo.key");
+	fs.writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
+	await utils.exec("sudo", ["apt-key", "add", keyFilePath]);
+}
+
+/**
+ * Add OSRF APT repository.
+ *
+ * @param ubuntuCodename the Ubuntu version codename
+ */
+async function addAptRepo(ubuntuCodename: string): Promise<void> {
+  await utils.exec("sudo", [
+    "bash",
+    "-c",
+    `echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" > /etc/apt/sources.list.d/gazebo-stable.list`,
+  ]);
+
+	await utils.exec("sudo", ["apt-get", "update"]);
+}
+
+/**
  * Install Gazebo on a Linux worker.
  */
 export async function runLinux(): Promise<void> {
-
 	await configOs();
+  await addAptRepoKey();
+
+	const ubuntuCodename = await utils.determineDistribCodename();
+	await addAptRepo(ubuntuCodename);
+
+  // Only there to test the installation of a gazebo. To be removed later
+  await utils.exec("sudo", ["apt-get", "install", "gz-garden"]);
 
 }

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -97,7 +97,7 @@ async function configOs(): Promise<void> {
  */
 async function addAptRepoKey(): Promise<void> {
 	const workspace = process.env.GITHUB_WORKSPACE as string;
-	const keyFilePath = path.join(workspace, "gazebo.key");
+	const keyFilePath = path.join(workspace, "/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg");
 	fs.writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
 	await utils.exec("sudo", ["apt-key", "add", keyFilePath]);
 }

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -28,7 +28,7 @@ async function configOs(): Promise<void> {
   await utils.exec("sudo", ["apt-get", "update"]);
 
   // Install tools required to configure the worker system.
-  await apt.runAptGetInstall(["wget", "curl", "gnupg2", "locales", "lsb-release"]);
+  await apt.runAptGetInstall(["wget", "curl", "gnupg2", "locales", "lsb-release", "ca-certificates"]);
 
   // Select a locale supporting Unicode.
   await utils.exec("sudo", ["locale-gen", "en_US", "en_US.UTF-8"]);

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -4,9 +4,6 @@ import * as io from "@actions/io";
 import * as apt from "./package_manager/apt";
 import * as utils from "./utils";
 
-import * as path from "path";
-import fs from "fs";
-
 /**
  * Configure basic OS stuff.
  */
@@ -91,5 +88,4 @@ export async function runLinux(): Promise<void> {
 
   // Only there to test the installation of a gazebo. To be removed later
   await apt.runAptGetInstall(['gz-garden',]);
-
 }

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -72,7 +72,6 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
     http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" | \
     sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
   ]);
-
 	await utils.exec("sudo", ["apt-get", "update"]);
 }
 
@@ -83,9 +82,11 @@ export async function runLinux(): Promise<void> {
 	await configOs();
   await addAptRepoKey();
 
+  // Add repo according to Ubuntu version
 	const ubuntuCodename = await utils.determineDistribCodename();
 	await addAptRepo(ubuntuCodename);
 
-  // Only there to test the installation of a gazebo. To be removed later
-  await apt.runAptGetInstall(['gz-garden',]);
+  for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
+		await apt.runAptGetInstall([`gz-${gazeboDistro}`]);
+	}
 }

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -57,8 +57,8 @@ async function addAptRepoKey(): Promise<void> {
 	await utils.exec("sudo", [
     "bash",
     "-c",
-    `wget --no-check-certificate https://packages.osrfoundation.org/gazebo.gpg -O
-    /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg`
+    `wget --no-check-certificate https://packages.osrfoundation.org/gazebo.gpg -O \
+    /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg`,
   ]);
 }
 
@@ -71,8 +71,8 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
   await utils.exec("sudo", [
     "bash",
     "-c",
-    `echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg]
-    http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" |
+    `echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] \
+    http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" | \
     sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
   ]);
 

--- a/src/setup-gazebo.ts
+++ b/src/setup-gazebo.ts
@@ -7,10 +7,10 @@ async function run() {
   }
   catch (error) {
     let errorMessage = "Unknown error";
-		if (error instanceof Error) {
-			errorMessage = error.message;
-		}
-		core.setFailed(errorMessage);
+    if (error instanceof Error) {
+      errorMessage = error.message;
+    }
+    core.setFailed(errorMessage);
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,16 +12,16 @@ import * as im from "@actions/exec/lib/interfaces";
  * @returns Promise<number> exit code
  */
 export async function exec(
-	commandLine: string,
-	args?: string[],
-	options?: im.ExecOptions,
-	log_message?: string,
+  commandLine: string,
+  args?: string[],
+  options?: im.ExecOptions,
+  log_message?: string,
 ): Promise<number> {
-	const argsAsString = (args || []).join(" ");
-	const message = log_message || `Invoking "${commandLine} ${argsAsString}"`;
-	return core.group(message, () => {
-		return actions_exec.exec(commandLine, args, options);
-	});
+  const argsAsString = (args || []).join(" ");
+  const message = log_message || `Invoking "${commandLine} ${argsAsString}"`;
+  return core.group(message, () => {
+    return actions_exec.exec(commandLine, args, options);
+  });
 }
 
 /**
@@ -33,19 +33,19 @@ export async function exec(
  * @returns Promise<string> Ubuntu distribution codename (e.g. "focal")
  */
 export async function determineDistribCodename(): Promise<string> {
-	let distribCodename = "";
-	const options: im.ExecOptions = {};
-	options.listeners = {
-		stdout: (data: Buffer) => {
-			distribCodename += data.toString();
-		},
-	};
-	await exec(
-		"bash",
-		["-c", 'source /etc/lsb-release ; echo -n "$DISTRIB_CODENAME"'],
-		options,
-	);
-	return distribCodename;
+  let distribCodename = "";
+  const options: im.ExecOptions = {};
+  options.listeners = {
+    stdout: (data: Buffer) => {
+      distribCodename += data.toString();
+    },
+  };
+  await exec(
+    "bash",
+    ["-c", 'source /etc/lsb-release ; echo -n "$DISTRIB_CODENAME"'],
+    options,
+  );
+  return distribCodename;
 }
 
 // List of valid Gazebo distributions
@@ -58,14 +58,14 @@ const validDistro: string[] = ["citadel", "fortress", "garden", "harmonic"];
  * @returns boolean Validity of Gazebo distribution
  */
 export function validateDistro(
-	requiredGazeboDistributionsList: string[],
+  requiredGazeboDistributionsList: string[],
 ): boolean {
-	for (const gazeboDistro of requiredGazeboDistributionsList) {
-		if (validDistro.indexOf(gazeboDistro) <= -1) {
-			return false;
-		}
-	}
-	return true;
+  for (const gazeboDistro of requiredGazeboDistributionsList) {
+    if (validDistro.indexOf(gazeboDistro) <= -1) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**
@@ -75,17 +75,17 @@ export function validateDistro(
  * @returns string[] List of validated Gazebo distributions
  */
 export function getRequiredGazeboDistributions(): string[] {
-	let requiredGazeboDistributionsList: string[] = [];
-	const requiredGazeboDistributions = core.getInput("required-gazebo-distributions");
-	if (requiredGazeboDistributions) {
-		requiredGazeboDistributionsList = requiredGazeboDistributions.split(
-			RegExp("\\s"),
-		);
-	} else {
+  let requiredGazeboDistributionsList: string[] = [];
+  const requiredGazeboDistributions = core.getInput("required-gazebo-distributions");
+  if (requiredGazeboDistributions) {
+    requiredGazeboDistributionsList = requiredGazeboDistributions.split(
+      RegExp("\\s"),
+    );
+  } else {
     throw new Error("Input cannot be empty.");
   }
-	if (!validateDistro(requiredGazeboDistributionsList)) {
-		throw new Error("Input has invalid distribution names.");
-	}
-	return requiredGazeboDistributionsList;
+  if (!validateDistro(requiredGazeboDistributionsList)) {
+    throw new Error("Input has invalid distribution names.");
+  }
+  return requiredGazeboDistributionsList;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,12 +51,11 @@ export async function determineDistribCodename(): Promise<string> {
 // List of valid Gazebo distributions
 const validDistro: string[] = ["citadel", "fortress", "garden", "humble"];
 
-//.
 /**
  * Validate all Gazebo input distribution names
  *
  * @param requiredGazeboDistributionsList
- * @returns boolean
+ * @returns boolean Validity of Gazebo distribution
  */
 export function validateDistro(
 	requiredGazeboDistributionsList: string[],
@@ -66,7 +65,6 @@ export function validateDistro(
 			return false;
 		}
 	}
-
 	return true;
 }
 
@@ -84,10 +82,8 @@ export function getRequiredGazeboDistributions(): string[] {
 			RegExp("\\s"),
 		);
 	}
-
 	if (!validateDistro(requiredGazeboDistributionsList)) {
 		throw new Error("Input has invalid distribution names.");
 	}
-
 	return requiredGazeboDistributionsList;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,3 +47,47 @@ export async function determineDistribCodename(): Promise<string> {
 	);
 	return distribCodename;
 }
+
+// List of valid Gazebo distributions
+const validDistro: string[] = ["citadel", "fortress", "garden", "humble"];
+
+//.
+/**
+ * Validate all Gazebo input distribution names
+ *
+ * @param requiredGazeboDistributionsList
+ * @returns boolean
+ */
+export function validateDistro(
+	requiredGazeboDistributionsList: string[],
+): boolean {
+	for (const gazeboDistro of requiredGazeboDistributionsList) {
+		if (validDistro.indexOf(gazeboDistro) <= -1) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Gets the input of the Gazebo distributions to be installed and
+ * validates them
+ *
+ * @returns string[] List of validated Gazebo distributions
+ */
+export function getRequiredGazeboDistributions(): string[] {
+	let requiredGazeboDistributionsList: string[] = [];
+	const requiredGazeboDistributions = core.getInput("required-gazebo-distributions");
+	if (requiredGazeboDistributions) {
+		requiredGazeboDistributionsList = requiredGazeboDistributions.split(
+			RegExp("\\s"),
+		);
+	}
+
+	if (!validateDistro(requiredGazeboDistributionsList)) {
+		throw new Error("Input has invalid distribution names.");
+	}
+
+	return requiredGazeboDistributionsList;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,7 @@ export async function determineDistribCodename(): Promise<string> {
 }
 
 // List of valid Gazebo distributions
-const validDistro: string[] = ["citadel", "fortress", "garden", "humble"];
+const validDistro: string[] = ["citadel", "fortress", "garden", "harmonic"];
 
 /**
  * Validate all Gazebo input distribution names

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,9 @@ export function getRequiredGazeboDistributions(): string[] {
 		requiredGazeboDistributionsList = requiredGazeboDistributions.split(
 			RegExp("\\s"),
 		);
-	}
+	} else {
+    throw new Error("Input cannot be empty.");
+  }
 	if (!validateDistro(requiredGazeboDistributionsList)) {
 		throw new Error("Input has invalid distribution names.");
 	}


### PR DESCRIPTION
## Summary
This PR is related to Issue #1. It creates a GitHub action to install a Gazebo release inside an Ubuntu distribution. 

`test.yml` file tests this workflow by creating multiple runners with an appropriate Gazebo + Ubuntu combination, shown below. 

```yml
      # Gazebo Citadel (Dec 2019 - Dec 2024)
      - docker_image: ubuntu:focal
        gazebo_distribution: citadel
  
  
      # Gazebo Fortress (Sep 2021 - Sep 2026)
      - docker_image: ubuntu:focal
        gazebo_distribution: fortress
  
  
      # Gazebo Garden (Sep 2022 - Nov 2024)
      - docker_image: ubuntu:focal
        gazebo_distribution: garden
  
  
      # Gazebo Harmonic (Sep 2023 - Sep 2028)
      - docker_image: ubuntu:jammy
        gazebo_distribution: harmonic
```

This workflow is set to run using the `workflow_dispatch` trigger. Testing this workflow will need the merge of PR #4 into `main` first (see PR for more details) 