### PR TITLE
Added support for prerelease and nightly repos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,3 +79,26 @@ jobs:
             echo "Neither ign nor gz command found"
             exit 1
           fi
+
+  test_gazebo_install_ubuntu_prerelease:
+    name: 'Check installation of Gazebo pre-release binary on Ubuntu'
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.docker_image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        docker_image:
+          - ubuntu:jammy
+          - ubuntu:noble
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: '20.x'
+      - name: 'Check Gazebo installation on Ubuntu runner'
+        uses: ./
+        with:
+          required-gazebo-distributions: 'harmonic'
+      - name: 'Test Gazebo installation'
+        run: 'gz sim --versions'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,5 +100,6 @@ jobs:
         uses: ./
         with:
           required-gazebo-distributions: 'harmonic'
+          use-gazebo-prerelease: 'true'
       - name: 'Test Gazebo installation'
         run: 'gz sim --versions'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,7 @@ jobs:
     name: 'Check installation of Gazebo nightly binary on Ubuntu'
     runs-on: ubuntu-latest
     container:
+      # Ionic should be running on Noble but existing bug is releasing it into Jammy
       image: ubuntu:jammy
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
     name: 'Check installation of Gazebo nightly binary on Ubuntu'
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:noble
+      image: ubuntu:jammy
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,13 +108,7 @@ jobs:
     name: 'Check installation of Gazebo nightly binary on Ubuntu'
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.docker_image }}
-    strategy:
-      fail-fast: false
-      matrix:
-        docker_image:
-          - ubuntu:jammy
-          - ubuntu:noble
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2
@@ -123,7 +117,7 @@ jobs:
       - name: 'Check Gazebo installation on Ubuntu runner'
         uses: ./
         with:
-          required-gazebo-distributions: 'harmonic'
+          required-gazebo-distributions: 'ionic'
           use-gazebo-nightly: 'true'
       - name: 'Test Gazebo installation'
         run: 'gz sim --versions'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,3 +103,27 @@ jobs:
           use-gazebo-prerelease: 'true'
       - name: 'Test Gazebo installation'
         run: 'gz sim --versions'
+
+  test_gazebo_install_ubuntu_nightly:
+    name: 'Check installation of Gazebo nightly binary on Ubuntu'
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.docker_image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        docker_image:
+          - ubuntu:jammy
+          - ubuntu:noble
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: '20.x'
+      - name: 'Check Gazebo installation on Ubuntu runner'
+        uses: ./
+        with:
+          required-gazebo-distributions: 'harmonic'
+          use-gazebo-nightly: 'true'
+      - name: 'Test Gazebo installation'
+        run: 'gz sim --versions'

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ out
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+.vscode

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -13,7 +13,7 @@ describe("workflow test without input", () => {
 		jest.resetAllMocks();
 	});
 
-	it("run Linux workflow without", async () => {
+	it("run Linux workflow without input", async () => {
 		await expect(linux.runLinux()).rejects.toThrow();
 	});
 });
@@ -28,7 +28,7 @@ describe("workflow test with a invalid distro input", () => {
 		jest.resetAllMocks();
 	});
 
-	it("run Linux workflow without", async () => {
+	it("run Linux workflow with invalid distro input", async () => {
 		await expect(linux.runLinux()).rejects.toThrow();
 	});
 });
@@ -43,7 +43,7 @@ describe("workflow test with a valid distro input", () => {
 		jest.resetAllMocks();
 	});
 
-	it("run Linux workflow without", async () => {
+	it("run Linux workflow with valid distro input", async () => {
 		await expect(linux.runLinux()).resolves.not.toThrow();
 	});
 });
@@ -66,5 +66,37 @@ describe("validate distribution test", () => {
 		await expect(utils.validateDistro(["citadel", "edifice", "harmonic"])).toBe(
 			false,
 		);
+	});
+});
+
+describe("check for unstable repositories input", () => {
+	beforeAll(() => {
+		jest.spyOn(exec, "exec").mockImplementation(jest.fn());
+		jest
+			.spyOn(utils, "checkForUnstableAptRepos")
+			.mockReturnValueOnce(["prerelease"]);
+		jest
+			.spyOn(utils, "checkForUnstableAptRepos")
+			.mockReturnValueOnce(["nightly"]);
+		jest
+			.spyOn(utils, "checkForUnstableAptRepos")
+			.mockReturnValueOnce(["prerelease", "nightly"]);
+		jest.spyOn(core, "getInput").mockReturnValue("harmonic");
+	});
+
+	afterAll(() => {
+		jest.resetAllMocks();
+	});
+
+	it("run Linux workflow with unstable repo prerelease", async () => {
+		await expect(linux.runLinux()).resolves.not.toThrow();
+	});
+
+	it("run Linux workflow with unstable repo nightly", async () => {
+		await expect(linux.runLinux()).resolves.not.toThrow();
+	});
+
+	it("run Linux workflow with both unstable repos", async () => {
+		await expect(linux.runLinux()).resolves.not.toThrow();
 	});
 });

--- a/action.yml
+++ b/action.yml
@@ -1,20 +1,31 @@
 name: 'Setup Gazebo release'
 description: |
   Install a Gazebo release on a Linux system
-required-gazebo-distributions:
+inputs:
+  required-gazebo-distributions:
+      description: |
+        List of Gazebo distributions to be installed.
+
+        Allowed Gazebo distributions
+        - citadel
+        - fortress
+        - garden
+        - harmonic
+
+        Multiple values can be passed using a whitespace delimited list
+        "fortress garden".
+      required: false
+      default: ''
+  use-gazebo-prerelease:
     description: |
-      List of Gazebo distributions to be installed.
-
-      Allowed Gazebo distributions
-      - citadel
-      - fortress
-      - garden
-      - harmonic
-
-      Multiple values can be passed using a whitespace delimited list
-      "fortress garden".
+      Use pre-release binaries from OSRF repository
     required: false
-    default: ''
+    default: 'false'
+  use-gazebo-nightly:
+    description: |
+      Use nightly binaries from OSRF repository
+    required: false
+    default: 'false'
 runs:
   using: node20
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -26342,8 +26342,8 @@ function addAptRepo(ubuntuCodename) {
                 "bash",
                 "-c",
                 `echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] \
-      http://packages.osrfoundation.org/gazebo/${unstableRepo} ${ubuntuCodename} main" | \
-      sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
+      http://packages.osrfoundation.org/gazebo/ubuntu-${unstableRepo} ${ubuntuCodename} main" | \
+      sudo tee /etc/apt/sources.list.d/gazebo-${unstableRepo}.list > /dev/null`,
             ]);
         }
         yield utils.exec("sudo", ["apt-get", "update"]);
@@ -26357,10 +26357,10 @@ function checkForUnstableAptRepos() {
             throw new Error("Cannot select Gazebo pre-release and nightly together.");
         }
         if (useGazeboPrerelease) {
-            return "ubuntu-prerelease";
+            return "prerelease";
         }
         else if (useGazeboNightly) {
-            return "ubuntu-nightly";
+            return "nightly";
         }
         else {
             return "";

--- a/dist/index.js
+++ b/dist/index.js
@@ -26336,8 +26336,8 @@ function addAptRepo(ubuntuCodename) {
     http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" | \
     sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
         ]);
-        const unstableRepo = yield checkForUnstableAptRepos();
-        if (unstableRepo !== "") {
+        const unstableRepos = yield checkForUnstableAptRepos();
+        for (const unstableRepo of unstableRepos) {
             yield utils.exec("sudo", [
                 "bash",
                 "-c",
@@ -26349,22 +26349,23 @@ function addAptRepo(ubuntuCodename) {
         yield utils.exec("sudo", ["apt-get", "update"]);
     });
 }
+/**
+ * Check for unstable repository inputs
+ *
+ * @returns unstableRepos unstable repository names
+ */
 function checkForUnstableAptRepos() {
     return __awaiter(this, void 0, void 0, function* () {
+        const unstableRepos = [];
         const useGazeboPrerelease = core.getInput("use-gazebo-prerelease") === "true";
-        const useGazeboNightly = core.getInput("use-gazebo-nightly") === "true";
-        if (useGazeboPrerelease && useGazeboNightly) {
-            throw new Error("Cannot select Gazebo pre-release and nightly together.");
-        }
         if (useGazeboPrerelease) {
-            return "prerelease";
+            unstableRepos.push("prerelease");
         }
-        else if (useGazeboNightly) {
-            return "nightly";
+        const useGazeboNightly = core.getInput("use-gazebo-nightly") === "true";
+        if (useGazeboNightly) {
+            unstableRepos.push("nightly");
         }
-        else {
-            return "";
-        }
+        return unstableRepos;
     });
 }
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -26511,7 +26511,13 @@ function determineDistribCodename() {
 }
 exports.determineDistribCodename = determineDistribCodename;
 // List of valid Gazebo distributions
-const validDistro = ["citadel", "fortress", "garden", "harmonic"];
+const validDistro = [
+    "citadel",
+    "fortress",
+    "garden",
+    "harmonic",
+    "ionic",
+];
 /**
  * Validate all Gazebo input distribution names
  *

--- a/dist/index.js
+++ b/dist/index.js
@@ -26336,7 +26336,35 @@ function addAptRepo(ubuntuCodename) {
     http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" | \
     sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
         ]);
+        const unstableRepo = yield checkForUnstableAptRepos();
+        if (unstableRepo !== "") {
+            yield utils.exec("sudo", [
+                "bash",
+                "-c",
+                `echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] \
+      http://packages.osrfoundation.org/gazebo/${unstableRepo} ${ubuntuCodename} main" | \
+      sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
+            ]);
+        }
         yield utils.exec("sudo", ["apt-get", "update"]);
+    });
+}
+function checkForUnstableAptRepos() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const useGazeboPrerelease = core.getInput("use-gazebo-prerelease") === "true";
+        const useGazeboNightly = core.getInput("use-gazebo-nightly") === "true";
+        if (useGazeboPrerelease && useGazeboNightly) {
+            throw new Error("Cannot select Gazebo pre-release and nightly together.");
+        }
+        if (useGazeboPrerelease) {
+            return "ubuntu-prerelease";
+        }
+        else if (useGazeboNightly) {
+            return "ubuntu-nightly";
+        }
+        else {
+            return "";
+        }
     });
 }
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -26336,7 +26336,7 @@ function addAptRepo(ubuntuCodename) {
     http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" | \
     sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
         ]);
-        const unstableRepos = yield checkForUnstableAptRepos();
+        const unstableRepos = utils.checkForUnstableAptRepos();
         for (const unstableRepo of unstableRepos) {
             yield utils.exec("sudo", [
                 "bash",
@@ -26347,25 +26347,6 @@ function addAptRepo(ubuntuCodename) {
             ]);
         }
         yield utils.exec("sudo", ["apt-get", "update"]);
-    });
-}
-/**
- * Check for unstable repository inputs
- *
- * @returns unstableRepos unstable repository names
- */
-function checkForUnstableAptRepos() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const unstableRepos = [];
-        const useGazeboPrerelease = core.getInput("use-gazebo-prerelease") === "true";
-        if (useGazeboPrerelease) {
-            unstableRepos.push("prerelease");
-        }
-        const useGazeboNightly = core.getInput("use-gazebo-nightly") === "true";
-        if (useGazeboNightly) {
-            unstableRepos.push("nightly");
-        }
-        return unstableRepos;
     });
 }
 /**
@@ -26485,7 +26466,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getRequiredGazeboDistributions = exports.validateDistro = exports.determineDistribCodename = exports.exec = void 0;
+exports.checkForUnstableAptRepos = exports.getRequiredGazeboDistributions = exports.validateDistro = exports.determineDistribCodename = exports.exec = void 0;
 const actions_exec = __importStar(__nccwpck_require__(1514));
 const core = __importStar(__nccwpck_require__(2186));
 /**
@@ -26567,6 +26548,24 @@ function getRequiredGazeboDistributions() {
     return requiredGazeboDistributionsList;
 }
 exports.getRequiredGazeboDistributions = getRequiredGazeboDistributions;
+/**
+ * Check for unstable repository inputs
+ *
+ * @returns unstableRepos unstable repository names
+ */
+function checkForUnstableAptRepos() {
+    const unstableRepos = [];
+    const useGazeboPrerelease = core.getInput("use-gazebo-prerelease") === "true";
+    if (useGazeboPrerelease) {
+        unstableRepos.push("prerelease");
+    }
+    const useGazeboNightly = core.getInput("use-gazebo-nightly") === "true";
+    if (useGazeboNightly) {
+        unstableRepos.push("nightly");
+    }
+    return unstableRepos;
+}
+exports.checkForUnstableAptRepos = checkForUnstableAptRepos;
 
 
 /***/ }),

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -85,8 +85,8 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
 			"bash",
 			"-c",
 			`echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] \
-      http://packages.osrfoundation.org/gazebo/${unstableRepo} ${ubuntuCodename} main" | \
-      sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
+      http://packages.osrfoundation.org/gazebo/ubuntu-${unstableRepo} ${ubuntuCodename} main" | \
+      sudo tee /etc/apt/sources.list.d/gazebo-${unstableRepo}.list > /dev/null`,
 		]);
 	}
 	await utils.exec("sudo", ["apt-get", "update"]);
@@ -100,9 +100,9 @@ async function checkForUnstableAptRepos(): Promise<string> {
 	}
 
 	if (useGazeboPrerelease) {
-		return "ubuntu-prerelease";
+		return "prerelease";
 	} else if (useGazeboNightly) {
-		return "ubuntu-nightly";
+		return "nightly";
 	} else {
 		return "";
 	}

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -79,7 +79,33 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
     http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" | \
     sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
 	]);
+	const unstableRepo = await checkForUnstableAptRepos();
+	if (unstableRepo !== "") {
+		await utils.exec("sudo", [
+			"bash",
+			"-c",
+			`echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] \
+      http://packages.osrfoundation.org/gazebo/${unstableRepo} ${ubuntuCodename} main" | \
+      sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
+		]);
+	}
 	await utils.exec("sudo", ["apt-get", "update"]);
+}
+
+async function checkForUnstableAptRepos(): Promise<string> {
+	const useGazeboPrerelease = core.getInput("use-gazebo-prerelease") === "true";
+	const useGazeboNightly = core.getInput("use-gazebo-nightly") === "true";
+	if (useGazeboPrerelease && useGazeboNightly) {
+		throw new Error("Cannot select Gazebo pre-release and nightly together.");
+	}
+
+	if (useGazeboPrerelease) {
+		return "ubuntu-prerelease";
+	} else if (useGazeboNightly) {
+		return "ubuntu-nightly";
+	} else {
+		return "";
+	}
 }
 
 /**

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -79,7 +79,7 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
     http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" | \
     sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
 	]);
-	const unstableRepos = await checkForUnstableAptRepos();
+	const unstableRepos = utils.checkForUnstableAptRepos();
 	for (const unstableRepo of unstableRepos) {
 		await utils.exec("sudo", [
 			"bash",
@@ -90,24 +90,6 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
 		]);
 	}
 	await utils.exec("sudo", ["apt-get", "update"]);
-}
-
-/**
- * Check for unstable repository inputs
- *
- * @returns unstableRepos unstable repository names
- */
-async function checkForUnstableAptRepos(): Promise<string[]> {
-	const unstableRepos: string[] = [];
-	const useGazeboPrerelease = core.getInput("use-gazebo-prerelease") === "true";
-	if (useGazeboPrerelease) {
-		unstableRepos.push("prerelease");
-	}
-	const useGazeboNightly = core.getInput("use-gazebo-nightly") === "true";
-	if (useGazeboNightly) {
-		unstableRepos.push("nightly");
-	}
-	return unstableRepos;
 }
 
 /**

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -79,8 +79,8 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
     http://packages.osrfoundation.org/gazebo/ubuntu-stable ${ubuntuCodename} main" | \
     sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null`,
 	]);
-	const unstableRepo = await checkForUnstableAptRepos();
-	if (unstableRepo !== "") {
+	const unstableRepos = await checkForUnstableAptRepos();
+	for (const unstableRepo of unstableRepos) {
 		await utils.exec("sudo", [
 			"bash",
 			"-c",
@@ -92,20 +92,22 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
 	await utils.exec("sudo", ["apt-get", "update"]);
 }
 
-async function checkForUnstableAptRepos(): Promise<string> {
+/**
+ * Check for unstable repository inputs
+ *
+ * @returns unstableRepos unstable repository names
+ */
+async function checkForUnstableAptRepos(): Promise<string[]> {
+	const unstableRepos: string[] = [];
 	const useGazeboPrerelease = core.getInput("use-gazebo-prerelease") === "true";
-	const useGazeboNightly = core.getInput("use-gazebo-nightly") === "true";
-	if (useGazeboPrerelease && useGazeboNightly) {
-		throw new Error("Cannot select Gazebo pre-release and nightly together.");
-	}
-
 	if (useGazeboPrerelease) {
-		return "prerelease";
-	} else if (useGazeboNightly) {
-		return "nightly";
-	} else {
-		return "";
+		unstableRepos.push("prerelease");
 	}
+	const useGazeboNightly = core.getInput("use-gazebo-nightly") === "true";
+	if (useGazeboNightly) {
+		unstableRepos.push("nightly");
+	}
+	return unstableRepos;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,13 @@ export async function determineDistribCodename(): Promise<string> {
 }
 
 // List of valid Gazebo distributions
-const validDistro: string[] = ["citadel", "fortress", "garden", "harmonic"];
+const validDistro: string[] = [
+	"citadel",
+	"fortress",
+	"garden",
+	"harmonic",
+	"ionic",
+];
 
 /**
  * Validate all Gazebo input distribution names

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,3 +91,21 @@ export function getRequiredGazeboDistributions(): string[] {
 	}
 	return requiredGazeboDistributionsList;
 }
+
+/**
+ * Check for unstable repository inputs
+ *
+ * @returns unstableRepos unstable repository names
+ */
+export function checkForUnstableAptRepos(): string[] {
+	const unstableRepos: string[] = [];
+	const useGazeboPrerelease = core.getInput("use-gazebo-prerelease") === "true";
+	if (useGazeboPrerelease) {
+		unstableRepos.push("prerelease");
+	}
+	const useGazeboNightly = core.getInput("use-gazebo-nightly") === "true";
+	if (useGazeboNightly) {
+		unstableRepos.push("nightly");
+	}
+	return unstableRepos;
+}


### PR DESCRIPTION
Closes #17 

## Summary

This PR adds support to `ubuntu-prerelease` and `ubuntu-nightly` Gazebo repositories.

Two additional tests have been added to the workflow to test the installation of `harmonic` on `jammy` and `noble` using the unstable repos.