### PR TITLE
Implemented action for MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
 
   test_gazebo_install_macos:
     name: 'Check installation of Gazebo on MacOS'
-    runs-on: macOs-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
 
   test_gazebo_install_macos:
     name: 'Check installation of Gazebo on MacOS'
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,6 +131,7 @@ jobs:
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: '20.x'
+      - uses: Homebrew/actions/setup-homebrew@master
       - name: 'Check Gazebo installation on MacOS runner'
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,3 +122,18 @@ jobs:
           use-gazebo-nightly: 'true'
       - name: 'Test Gazebo installation'
         run: 'gz sim --versions'
+
+  test_gazebo_install_macos:
+    name: 'Check installation of Gazebo on MacOS'
+    runs-on: macOs-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: '20.x'
+      - name: 'Check Gazebo installation on MacOS runner'
+        uses: ./
+        with:
+          required-gazebo-distributions: 'harmonic'
+      - name: 'Test Gazebo installation'
+        run: 'gz sim --versions'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          # MacOS Monterey
           - macos-12
+
+          # MacOS Ventura
           - macos-13
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,13 +125,18 @@ jobs:
 
   test_gazebo_install_macos:
     name: 'Check installation of Gazebo on MacOS'
-    runs-on: macos-13
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-12
+          - macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: '20.x'
-      # - uses: Homebrew/actions/setup-homebrew@master
       - name: 'Check Gazebo installation on MacOS runner'
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: '20.x'
-      - uses: Homebrew/actions/setup-homebrew@master
+      # - uses: Homebrew/actions/setup-homebrew@master
       - name: 'Check Gazebo installation on MacOS runner'
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ This action sets up a Gazebo release inside a Linux environment.
 1. [Supported platforms](#Supported-platforms)
 1. [Tasks performed by the action](#Tasks-performed-by-the-action)
 1. [Usage](#Usage)
-    1. [Setting up worker and installing a compatible Gazebo and Ubuntu combination](#Setting-up-worker-and-installing-a-compatible-Gazebo-and-Ubuntu-combination)
-    1. [Iterating on all Gazebo and Ubuntu combinations](#Iterating-on-all-gazebo-ubuntu-combinations)
-    1. [Using pre-release and/or nightly Gazebo binaries](#Using-pre-release-and/or-nightly-Gazebo-binaries)
-    1. [Setting up worker to install Gazebo on macOS](#Setting-up-worker-to-install-Gazebo-on-macOS)
+    1. [Ubuntu](#Ubuntu)
+        1. [Setting up worker and installing a compatible Gazebo and Ubuntu combination](#Setting-up-worker-and-installing-a-compatible-Gazebo-and-Ubuntu-combination)
+        1. [Iterating on all Gazebo and Ubuntu combinations](#Iterating-on-all-gazebo-ubuntu-combinations)
+        1. [Using pre-release and/or nightly Gazebo binaries](#Using-pre-release-and/or-nightly-Gazebo-binaries)
+    2. [MacOS](#MacOS)
+        1. [Setting up worker to install Gazebo on macOS](#Setting-up-worker-to-install-Gazebo-on-macOS)
 1. [License](#License)
 
 ## Overview
@@ -33,8 +35,7 @@ The `setup-gazebo` action performs the following tasks:
   - Install necessary APT packages
   - Registers the Open Robotics APT repository
 - On macOS:
-  - Tapping into OSRF repository using Homebrew
-
+  - Tapping into the [osrf/homebrew-simulation](https://github.com/osrf/homebrew-simulation) using Homebrew
 ## Usage
 
 See [action.yml](action.yml)
@@ -47,7 +48,9 @@ See [action.yml](action.yml)
 >
 > This action can also be used with the `main` branch - `gazebo-tooling/setup-gazebo@main`. Use with caution as compatibility is not guaranteed!
 
-### Setting up worker and installing a compatible Gazebo and Ubuntu combination
+### Ubuntu
+
+#### Setting up worker and installing a compatible Gazebo and Ubuntu combination
 
 This workflow shows how to spawn a job to install Gazebo using the action. The action needs an input in the `required-gazebo-distributions` field and requires a Docker configuration to run seamlessly.
 
@@ -72,7 +75,7 @@ The following code snippet shows the installation of Gazebo Harmonic on Ubuntu N
           run: 'gz sim --versions'
 ```
 
-### Iterating on all Gazebo and Ubuntu combinations
+#### Iterating on all Gazebo and Ubuntu combinations
 
 This workflow shows how to spawn one job per Gazebo release. It iterates over all specified Gazebo and Ubuntu combinations using Docker. For example, Gazebo Garden is paired with Ubuntu Focal while Gazebo Harmonic is paired with Ubuntu Jammy.
 
@@ -127,7 +130,7 @@ This workflow shows how to spawn one job per Gazebo release. It iterates over al
             fi
 ```
 
-### Using pre-release and/or nightly Gazebo binaries
+#### Using pre-release and/or nightly Gazebo binaries
 
 This workflow shows how to use binaries from [pre-release] or [nightly] Gazebo repositories instead of the stable repository by setting the `use-gazebo-prerelease` or `use-gazebo-nightly` to `true`.
 
@@ -152,7 +155,9 @@ This workflow shows how to use binaries from [pre-release] or [nightly] Gazebo r
             run: 'gz sim --versions'
 ```
 
-### Setting up worker to install Gazebo on macOS
+### MacOS
+
+#### Setting up worker to install Gazebo on macOS
 
 This workflow shows how to install Gazebo on a macOS worker. The action needs an input for `required-gazebo-distributions` parameter.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This action sets up a Gazebo release inside a Linux environment.
     1. [Setting up worker and installing a compatible Gazebo and Ubuntu combination](#Setting-up-worker-and-installing-a-compatible-Gazebo-and-Ubuntu-combination)
     1. [Iterating on all Gazebo and Ubuntu combinations](#Iterating-on-all-gazebo-ubuntu-combinations)
     1. [Using pre-release and/or nightly Gazebo binaries](#Using-pre-release-and/or-nightly-Gazebo-binaries)
+    1. [Setting up worker to install Gazebo on macOS](#Setting-up-worker-to-install-Gazebo-on-macOS)
 1. [License](#License)
 
 ## Overview
@@ -19,18 +20,20 @@ It is recommended to use the `setup-gazebo` action inside a Docker container due
 
 ## Supported platforms
 
-`setup-gazebo` action works for all non-EOL Gazebo [releases] on [officially] supported platforms (Ubuntu).
-
-> [!NOTE]
-> There is a plan to implement this action for the [best-effort] supported platforms.
+`setup-gazebo` action works for all non-EOL Gazebo [releases] on the following platforms:
+  - Ubuntu
+  - macOS
 
 ## Tasks performed by the action
 
-The `setup-gazebo` action performs the following tasks on an Ubuntu system:
-- Installs `sudo` in case it is missing
-- Sets the locale to `en_US.UTF-8` and timezone to `UTC`
-- Install necessary APT packages
-- Registers the Open Robotics APT repository
+The `setup-gazebo` action performs the following tasks:
+- On Ubuntu:
+  - Installs `sudo` in case it is missing
+  - Sets the locale to `en_US.UTF-8` and timezone to `UTC`
+  - Install necessary APT packages
+  - Registers the Open Robotics APT repository
+- On macOS:
+  - Tapping into OSRF repository using Homebrew
 
 ## Usage
 
@@ -131,7 +134,6 @@ This workflow shows how to use binaries from [pre-release] or [nightly] Gazebo r
 ```yaml
   jobs:
     test_gazebo:
-        name: 'Check installation of Gazebo nightly binary on Ubuntu'
         runs-on: ubuntu-latest
         container:
           image: ubuntu:noble
@@ -148,6 +150,26 @@ This workflow shows how to use binaries from [pre-release] or [nightly] Gazebo r
               use-gazebo-nightly: 'true'
           - name: 'Test Gazebo installation'
             run: 'gz sim --versions'
+```
+
+### Setting up worker to install Gazebo on macOS
+
+This workflow shows how to install Gazebo on a macOS worker. The action needs an input for `required-gazebo-distributions` parameter.
+
+```yaml
+  test_gazebo:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: '20.x'
+      - name: 'Check Gazebo installation on MacOS runner'
+        uses: gazebo-tooling/setup-gazebo@<full_commit_hash>
+        with:
+          required-gazebo-distributions: 'harmonic'
+      - name: 'Test Gazebo installation'
+        run: 'gz sim --versions'
 ```
 
 ## License

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -2,6 +2,7 @@ import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 
 import * as linux from "../src/setup-gazebo-linux";
+import * as macOs from "../src/setup-gazebo-macos";
 import * as utils from "../src/utils";
 
 describe("workflow test without input", () => {
@@ -15,6 +16,10 @@ describe("workflow test without input", () => {
 
 	it("run Linux workflow without input", async () => {
 		await expect(linux.runLinux()).rejects.toThrow();
+	});
+
+	it("run macOS workflow without input", async () => {
+		await expect(macOs.runMacOs()).rejects.toThrow();
 	});
 });
 
@@ -31,6 +36,10 @@ describe("workflow test with a invalid distro input", () => {
 	it("run Linux workflow with invalid distro input", async () => {
 		await expect(linux.runLinux()).rejects.toThrow();
 	});
+
+	it("run macOS workflow with invalid distro input", async () => {
+		await expect(macOs.runMacOs()).rejects.toThrow();
+	});
 });
 
 describe("workflow test with a valid distro input", () => {
@@ -45,6 +54,10 @@ describe("workflow test with a valid distro input", () => {
 
 	it("run Linux workflow with valid distro input", async () => {
 		await expect(linux.runLinux()).resolves.not.toThrow();
+	});
+
+	it("run macOS workflow with valid distro input", async () => {
+		await expect(macOs.runMacOs()).resolves.not.toThrow();
 	});
 });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -26463,8 +26463,7 @@ const utils = __importStar(__nccwpck_require__(1314));
 const brew = __importStar(__nccwpck_require__(9586));
 function configureBrew() {
     return __awaiter(this, void 0, void 0, function* () {
-        yield utils.exec("sudo", [
-            "bash",
+        yield utils.exec("/bin/bash", [
             "-c",
             "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)",
         ]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -26461,20 +26461,19 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.runMacOs = void 0;
 const utils = __importStar(__nccwpck_require__(1314));
 const brew = __importStar(__nccwpck_require__(9586));
-// async function configureBrew() {
-// 	await utils.exec("/bin/bash", [
-// 		"-c",
-// 		"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)",
-// 	]);
-// }
+/**
+ * Tap into OSRF repository
+ */
 function addBrewRepo() {
     return __awaiter(this, void 0, void 0, function* () {
         yield utils.exec("brew", ["tap", "osrf/simulation"]);
     });
 }
+/**
+ * Install Gazebo on MacOS worker
+ */
 function runMacOs() {
     return __awaiter(this, void 0, void 0, function* () {
-        // await configureBrew();
         yield addBrewRepo();
         for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
             yield brew.runBrew([`gz-${gazeboDistro}`]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -26200,12 +26200,7 @@ const aptCommandLine = [
  *
  * This invokation guarantees that APT install will be non-blocking.
  *
- * In particular, it automatically accepts the RTI Connext license, which would block forever otherwise.
- * Skipping the license agreement page requires RTI_NC_LICENSE_ACCEPTED to be set to "yes".
- * This package would normally be installed automatically by rosdep, but
- * there is no way to pass RTI_NC_LICENSE_ACCEPTED through rosdep.
- *
- * @param   packages        list of Debian pacakges to be installed
+ * @param   packages list of Debian pacakges to be installed
  * @returns Promise<number> exit code
  */
 function runAptGetInstall(packages) {
@@ -26214,6 +26209,62 @@ function runAptGetInstall(packages) {
     });
 }
 exports.runAptGetInstall = runAptGetInstall;
+
+
+/***/ }),
+
+/***/ 9586:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.runBrew = void 0;
+const utils = __importStar(__nccwpck_require__(1314));
+/**
+ * Run brew install on a list of specified packages.
+ *
+ * @param   packages list of Homebrew packages to be installed
+ * @returns Promise<number> exit code
+ */
+function runBrew(packages) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return utils.exec("brew", ["install"].concat(packages));
+    });
+}
+exports.runBrew = runBrew;
 
 
 /***/ }),
@@ -26369,6 +26420,75 @@ exports.runLinux = runLinux;
 
 /***/ }),
 
+/***/ 8247:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.runMacOs = void 0;
+const utils = __importStar(__nccwpck_require__(1314));
+const brew = __importStar(__nccwpck_require__(9586));
+function configureBrew() {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield utils.exec("sudo", [
+            "bash",
+            "-c",
+            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)",
+        ]);
+    });
+}
+function addBrewRepo() {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield utils.exec("brew", ["tap", "osrf/simulation"]);
+    });
+}
+function runMacOs() {
+    return __awaiter(this, void 0, void 0, function* () {
+        configureBrew();
+        addBrewRepo();
+        for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
+            yield brew.runBrew([`gz-${gazeboDistro}`]);
+        }
+    });
+}
+exports.runMacOs = runMacOs;
+
+
+/***/ }),
+
 /***/ 525:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -26409,10 +26529,20 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
 const linux = __importStar(__nccwpck_require__(5467));
+const macOs = __importStar(__nccwpck_require__(8247));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            linux.runLinux();
+            const platform = process.platform;
+            if (platform === "darwin") {
+                macOs.runMacOs();
+            }
+            else if (platform === "linux") {
+                linux.runLinux();
+            }
+            else {
+                throw new Error(`Unsupported platform ${platform}`);
+            }
         }
         catch (error) {
             let errorMessage = "Unknown error";

--- a/dist/index.js
+++ b/dist/index.js
@@ -26476,8 +26476,8 @@ function addBrewRepo() {
 }
 function runMacOs() {
     return __awaiter(this, void 0, void 0, function* () {
-        configureBrew();
-        addBrewRepo();
+        yield configureBrew();
+        yield addBrewRepo();
         for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
             yield brew.runBrew([`gz-${gazeboDistro}`]);
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -26461,14 +26461,12 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.runMacOs = void 0;
 const utils = __importStar(__nccwpck_require__(1314));
 const brew = __importStar(__nccwpck_require__(9586));
-function configureBrew() {
-    return __awaiter(this, void 0, void 0, function* () {
-        yield utils.exec("/bin/bash", [
-            "-c",
-            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)",
-        ]);
-    });
-}
+// async function configureBrew() {
+// 	await utils.exec("/bin/bash", [
+// 		"-c",
+// 		"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)",
+// 	]);
+// }
 function addBrewRepo() {
     return __awaiter(this, void 0, void 0, function* () {
         yield utils.exec("brew", ["tap", "osrf/simulation"]);
@@ -26476,7 +26474,7 @@ function addBrewRepo() {
 }
 function runMacOs() {
     return __awaiter(this, void 0, void 0, function* () {
-        yield configureBrew();
+        // await configureBrew();
         yield addBrewRepo();
         for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
             yield brew.runBrew([`gz-${gazeboDistro}`]);

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -14,12 +14,7 @@ const aptCommandLine: string[] = [
  *
  * This invokation guarantees that APT install will be non-blocking.
  *
- * In particular, it automatically accepts the RTI Connext license, which would block forever otherwise.
- * Skipping the license agreement page requires RTI_NC_LICENSE_ACCEPTED to be set to "yes".
- * This package would normally be installed automatically by rosdep, but
- * there is no way to pass RTI_NC_LICENSE_ACCEPTED through rosdep.
- *
- * @param   packages        list of Debian pacakges to be installed
+ * @param   packages list of Debian pacakges to be installed
  * @returns Promise<number> exit code
  */
 export async function runAptGetInstall(packages: string[]): Promise<number> {

--- a/src/package_manager/brew.ts
+++ b/src/package_manager/brew.ts
@@ -1,0 +1,11 @@
+import * as utils from "../utils";
+
+/**
+ * Run brew install on a list of specified packages.
+ *
+ * @param   packages list of Homebrew packages to be installed
+ * @returns Promise<number> exit code
+ */
+export async function runBrew(packages: string[]): Promise<number> {
+	return utils.exec("brew", ["install"].concat(packages));
+}

--- a/src/setup-gazebo-macos.ts
+++ b/src/setup-gazebo-macos.ts
@@ -1,19 +1,19 @@
 import * as utils from "./utils";
 import * as brew from "./package_manager/brew";
 
-async function configureBrew() {
-	await utils.exec("/bin/bash", [
-		"-c",
-		"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)",
-	]);
-}
+// async function configureBrew() {
+// 	await utils.exec("/bin/bash", [
+// 		"-c",
+// 		"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)",
+// 	]);
+// }
 
 async function addBrewRepo() {
 	await utils.exec("brew", ["tap", "osrf/simulation"]);
 }
 
 export async function runMacOs() {
-	await configureBrew();
+	// await configureBrew();
 
 	await addBrewRepo();
 

--- a/src/setup-gazebo-macos.ts
+++ b/src/setup-gazebo-macos.ts
@@ -1,20 +1,17 @@
 import * as utils from "./utils";
 import * as brew from "./package_manager/brew";
 
-// async function configureBrew() {
-// 	await utils.exec("/bin/bash", [
-// 		"-c",
-// 		"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)",
-// 	]);
-// }
-
+/**
+ * Tap into OSRF repository
+ */
 async function addBrewRepo() {
 	await utils.exec("brew", ["tap", "osrf/simulation"]);
 }
 
+/**
+ * Install Gazebo on MacOS worker
+ */
 export async function runMacOs() {
-	// await configureBrew();
-
 	await addBrewRepo();
 
 	for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {

--- a/src/setup-gazebo-macos.ts
+++ b/src/setup-gazebo-macos.ts
@@ -1,0 +1,24 @@
+import * as utils from "./utils";
+import * as brew from "./package_manager/brew";
+
+async function configureBrew() {
+	await utils.exec("sudo", [
+		"bash",
+		"-c",
+		"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)",
+	]);
+}
+
+async function addBrewRepo() {
+	await utils.exec("brew", ["tap", "osrf/simulation"]);
+}
+
+export async function runMacOs() {
+	configureBrew();
+
+	addBrewRepo();
+
+	for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
+		await brew.runBrew([`gz-${gazeboDistro}`]);
+	}
+}

--- a/src/setup-gazebo-macos.ts
+++ b/src/setup-gazebo-macos.ts
@@ -13,9 +13,9 @@ async function addBrewRepo() {
 }
 
 export async function runMacOs() {
-	configureBrew();
+	await configureBrew();
 
-	addBrewRepo();
+	await addBrewRepo();
 
 	for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
 		await brew.runBrew([`gz-${gazeboDistro}`]);

--- a/src/setup-gazebo-macos.ts
+++ b/src/setup-gazebo-macos.ts
@@ -2,8 +2,7 @@ import * as utils from "./utils";
 import * as brew from "./package_manager/brew";
 
 async function configureBrew() {
-	await utils.exec("sudo", [
-		"bash",
+	await utils.exec("/bin/bash", [
 		"-c",
 		"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)",
 	]);

--- a/src/setup-gazebo.ts
+++ b/src/setup-gazebo.ts
@@ -1,9 +1,17 @@
 import * as core from "@actions/core";
 import * as linux from "./setup-gazebo-linux";
+import * as macOs from "./setup-gazebo-macos";
 
 async function run() {
 	try {
-		linux.runLinux();
+		const platform = process.platform;
+		if (platform === "darwin") {
+			macOs.runMacOs();
+		} else if (platform === "linux") {
+			linux.runLinux();
+		} else {
+			throw new Error(`Unsupported platform ${platform}`);
+		}
 	} catch (error) {
 		let errorMessage = "Unknown error";
 		if (error instanceof Error) {


### PR DESCRIPTION
Closes #18 

## Summary

This action can now be used to install Gazebo on MacOS. Additionally, updated the usage section of the README and added associated unit tests.  

Added a job in `test.yml` to test the working of this action. This job installs Gazebo Harmonic on MacOS 12 (Monterey) and 13 (Ventura), as mentioned [here](https://gazebosim.org/docs/harmonic/getstarted#step-1-install).