### PR TITLE
Adding action support for windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,5 +159,9 @@ jobs:
         with:
           node-version: '20.x'
       - uses: conda-incubator/setup-miniconda@v3
-      - shell: pwsh
-        run: conda list
+      - name: 'Check Gazebo installation on Windows runner'
+        uses: ./
+        with:
+          required-gazebo-distributions: 'harmonic'
+      - name: 'Test Gazebo installation'
+        run: 'gz sim --versions'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,4 +166,6 @@ jobs:
         with:
           required-gazebo-distributions: 'harmonic'
       - name: 'Test Gazebo installation'
-        run: 'gz sim --versions'
+        run: |
+          conda activate
+          gz sim --versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,11 +159,11 @@ jobs:
         with:
           node-version: '20.x'
       - uses: conda-incubator/setup-miniconda@v3
-      - shell: pwsh
-        run: 'conda install gz-sim8 --channel conda-forge'
-      # - name: 'Check Gazebo installation on Windows runner'
-      #   uses: ./
-      #   with:
-      #     required-gazebo-distributions: 'harmonic'
-      # - name: 'Test Gazebo installation'
-      #   run: 'gz sim --versions'
+      # - shell: pwsh
+      #   run: 'conda install gz-sim8 --channel conda-forge'
+      - name: 'Check Gazebo installation on Windows runner'
+        uses: ./
+        with:
+          required-gazebo-distributions: 'harmonic'
+      - name: 'Test Gazebo installation'
+        run: 'gz sim --versions'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,5 +168,5 @@ jobs:
       - name: 'Test Gazebo installation'
         shell: pwsh
         run: |
-          conda activate gz_env
+          conda activate gz-env
           gz sim --versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,8 +159,6 @@ jobs:
         with:
           node-version: '20.x'
       - uses: conda-incubator/setup-miniconda@v3
-      # - shell: pwsh
-      #   run: 'conda install gz-sim8 --channel conda-forge'
       - name: 'Check Gazebo installation on Windows runner'
         uses: ./
         with:
@@ -168,5 +166,5 @@ jobs:
       - name: 'Test Gazebo installation'
         shell: pwsh
         run: |
-          conda activate gz-env
+          conda activate
           gz sim --versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,9 +159,11 @@ jobs:
         with:
           node-version: '20.x'
       - uses: conda-incubator/setup-miniconda@v3
-      - name: 'Check Gazebo installation on Windows runner'
-        uses: ./
-        with:
-          required-gazebo-distributions: 'harmonic'
-      - name: 'Test Gazebo installation'
-        run: 'gz sim --versions'
+      - shell: pwsh
+        run: 'conda search libgz-sim* --channel conda-forge'
+      # - name: 'Check Gazebo installation on Windows runner'
+      #   uses: ./
+      #   with:
+      #     required-gazebo-distributions: 'harmonic'
+      # - name: 'Test Gazebo installation'
+      #   run: 'gz sim --versions'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,5 +168,5 @@ jobs:
       - name: 'Test Gazebo installation'
         shell: pwsh
         run: |
-          conda activate
+          conda activate gz_env
           gz sim --versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,6 +166,7 @@ jobs:
         with:
           required-gazebo-distributions: 'harmonic'
       - name: 'Test Gazebo installation'
+        shell: pwsh
         run: |
           conda activate
           gz sim --versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,3 +149,15 @@ jobs:
           required-gazebo-distributions: 'harmonic'
       - name: 'Test Gazebo installation'
         run: 'gz sim --versions'
+
+  test_gazebo_install_windows:
+    name: 'Check installation of Gazebo on Windows'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: '20.x'
+      - uses: conda-incubator/setup-miniconda@v3
+      - shell: pwsh
+        run: conda list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,7 @@ jobs:
           node-version: '20.x'
       - uses: conda-incubator/setup-miniconda@v3
       - shell: pwsh
-        run: 'conda search libgz-sim* --channel conda-forge'
+        run: 'conda install gz-sim8 --channel conda-forge'
       # - name: 'Check Gazebo installation on Windows runner'
       #   uses: ./
       #   with:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ This action sets up a Gazebo release inside a Linux environment.
         1. [Setting up worker and installing a compatible Gazebo and Ubuntu combination](#Setting-up-worker-and-installing-a-compatible-Gazebo-and-Ubuntu-combination)
         1. [Iterating on all Gazebo and Ubuntu combinations](#Iterating-on-all-gazebo-ubuntu-combinations)
         1. [Using pre-release and/or nightly Gazebo binaries](#Using-pre-release-and/or-nightly-Gazebo-binaries)
-    2. [MacOS](#MacOS)
+    2. [macOS](#macOS)
         1. [Setting up worker to install Gazebo on macOS](#Setting-up-worker-to-install-Gazebo-on-macOS)
+    3. [Windows](#Windows)
+        1. [Setting up worker to install Gazebo on Windows](#Setting-up-worker-to-install-Gazebo-on-Windows)
 1. [License](#License)
 
 ## Overview
@@ -25,6 +27,7 @@ It is recommended to use the `setup-gazebo` action inside a Docker container due
 `setup-gazebo` action works for all non-EOL Gazebo [releases] on the following platforms:
   - Ubuntu
   - macOS
+  - Windows
 
 ## Tasks performed by the action
 
@@ -36,6 +39,8 @@ The `setup-gazebo` action performs the following tasks:
   - Registers the Open Robotics APT repository
 - On macOS:
   - Tapping into the [osrf/homebrew-simulation](https://github.com/osrf/homebrew-simulation) using Homebrew
+- On Windows:
+  - Installing Gazebo using Conda from conda-forge
 ## Usage
 
 See [action.yml](action.yml)
@@ -155,7 +160,7 @@ This workflow shows how to use binaries from [pre-release] or [nightly] Gazebo r
             run: 'gz sim --versions'
 ```
 
-### MacOS
+### macOS
 
 #### Setting up worker to install Gazebo on macOS
 
@@ -175,6 +180,32 @@ This workflow shows how to install Gazebo on a macOS worker. The action needs an
           required-gazebo-distributions: 'harmonic'
       - name: 'Test Gazebo installation'
         run: 'gz sim --versions'
+```
+
+### Windows
+
+This workflow shows how to install Gazebo on a Windows worker. The action requires a Conda package management system such as miniconda as all Gazebo packages are available on conda-forge. The action is run by specifying the distribution of choice in `required-gazebo-distributions` field.
+
+#### Setting up worker to install Gazebo on Windows
+
+```yaml
+  test_gazebo:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: '20.x'
+      - uses: conda-incubator/setup-miniconda@v3
+      - name: 'Check Gazebo installation on Windows runner'
+        uses: gazebo-tooling/setup-gazebo@<full_commit_hash>
+        with:
+          required-gazebo-distributions: 'harmonic'
+      - name: 'Test Gazebo installation'
+        shell: pwsh
+        run: |
+          conda activate
+          gz sim --versions
 ```
 
 ## License

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -3,6 +3,7 @@ import * as exec from "@actions/exec";
 
 import * as linux from "../src/setup-gazebo-linux";
 import * as macOs from "../src/setup-gazebo-macos";
+import * as windows from "../src/setup-gazebo-windows";
 import * as utils from "../src/utils";
 
 describe("workflow test without input", () => {
@@ -18,8 +19,12 @@ describe("workflow test without input", () => {
 		await expect(linux.runLinux()).rejects.toThrow();
 	});
 
-	it("run macOS workflow without input", async () => {
+	it("run MacOS workflow without input", async () => {
 		await expect(macOs.runMacOs()).rejects.toThrow();
+	});
+
+	it("run Windows workflow without input", async () => {
+		await expect(windows.runWindows()).rejects.toThrow();
 	});
 });
 
@@ -37,8 +42,12 @@ describe("workflow test with a invalid distro input", () => {
 		await expect(linux.runLinux()).rejects.toThrow();
 	});
 
-	it("run macOS workflow with invalid distro input", async () => {
+	it("run MacOS workflow with invalid distro input", async () => {
 		await expect(macOs.runMacOs()).rejects.toThrow();
+	});
+
+	it("run Windows workflow with invalid distro input", async () => {
+		await expect(windows.runWindows()).rejects.toThrow();
 	});
 });
 
@@ -56,8 +65,12 @@ describe("workflow test with a valid distro input", () => {
 		await expect(linux.runLinux()).resolves.not.toThrow();
 	});
 
-	it("run macOS workflow with valid distro input", async () => {
+	it("run MacOS workflow with valid distro input", async () => {
 		await expect(macOs.runMacOs()).resolves.not.toThrow();
+	});
+
+	it("run Windows workflow with valid distro input", async () => {
+		await expect(windows.runWindows()).resolves.not.toThrow();
 	});
 });
 

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -19,7 +19,7 @@ describe("workflow test without input", () => {
 		await expect(linux.runLinux()).rejects.toThrow();
 	});
 
-	it("run MacOS workflow without input", async () => {
+	it("run macOS workflow without input", async () => {
 		await expect(macOs.runMacOs()).rejects.toThrow();
 	});
 
@@ -42,7 +42,7 @@ describe("workflow test with a invalid distro input", () => {
 		await expect(linux.runLinux()).rejects.toThrow();
 	});
 
-	it("run MacOS workflow with invalid distro input", async () => {
+	it("run macOS workflow with invalid distro input", async () => {
 		await expect(macOs.runMacOs()).rejects.toThrow();
 	});
 
@@ -65,7 +65,7 @@ describe("workflow test with a valid distro input", () => {
 		await expect(linux.runLinux()).resolves.not.toThrow();
 	});
 
-	it("run MacOS workflow with valid distro input", async () => {
+	it("run macOS workflow with valid distro input", async () => {
 		await expect(macOs.runMacOs()).resolves.not.toThrow();
 	});
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -26317,7 +26317,7 @@ const utils = __importStar(__nccwpck_require__(1314));
  */
 function runConda(packages) {
     return __awaiter(this, void 0, void 0, function* () {
-        return utils.exec("conda", ["install"].concat(packages).concat(["--channel conda-forge"]));
+        return utils.exec("conda", ["install"].concat(packages).concat("--channel conda-forge"));
     });
 }
 exports.runConda = runConda;

--- a/dist/index.js
+++ b/dist/index.js
@@ -26269,6 +26269,62 @@ exports.runBrew = runBrew;
 
 /***/ }),
 
+/***/ 7725:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.runConda = void 0;
+const utils = __importStar(__nccwpck_require__(1314));
+/**
+ * Run conda install on a list of specified packages.
+ *
+ * @param   packages list of conda-forge packages to be installed
+ * @returns Promise<number> exit code
+ */
+function runConda(packages) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return utils.exec("conda", ["install"].concat(packages).concat(["--channel conda-forge"]));
+    });
+}
+exports.runConda = runConda;
+
+
+/***/ }),
+
 /***/ 5467:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -26485,6 +26541,56 @@ exports.runMacOs = runMacOs;
 
 /***/ }),
 
+/***/ 8502:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.runWindows = void 0;
+const conda = __importStar(__nccwpck_require__(7725));
+function runWindows() {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield conda.runConda(["gz-sim8"]);
+    });
+}
+exports.runWindows = runWindows;
+
+
+/***/ }),
+
 /***/ 525:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -26526,6 +26632,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
 const linux = __importStar(__nccwpck_require__(5467));
 const macOs = __importStar(__nccwpck_require__(8247));
+const windows = __importStar(__nccwpck_require__(8502));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -26535,6 +26642,9 @@ function run() {
             }
             else if (platform === "linux") {
                 linux.runLinux();
+            }
+            else if (platform === "win32") {
+                windows.runWindows();
             }
             else {
                 throw new Error(`Unsupported platform ${platform}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -26269,62 +26269,6 @@ exports.runBrew = runBrew;
 
 /***/ }),
 
-/***/ 7725:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.runConda = void 0;
-const utils = __importStar(__nccwpck_require__(1314));
-/**
- * Run conda install on a list of specified packages.
- *
- * @param   packages list of conda-forge packages to be installed
- * @returns Promise<number> exit code
- */
-function runConda(packages) {
-    return __awaiter(this, void 0, void 0, function* () {
-        return utils.exec("conda", ["install"].concat(packages).concat("--channel conda-forge"));
-    });
-}
-exports.runConda = runConda;
-
-
-/***/ }),
-
 /***/ 5467:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -26580,10 +26524,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.runWindows = void 0;
-const conda = __importStar(__nccwpck_require__(7725));
+const utils = __importStar(__nccwpck_require__(1314));
 function runWindows() {
     return __awaiter(this, void 0, void 0, function* () {
-        yield conda.runConda(["gz-sim8"]);
+        // await conda.runConda(["gz-sim8"]);
+        yield utils.exec("conda", [
+            "search",
+            "libgz-sim*",
+            "--channel",
+            "conda-forge",
+        ]);
+        yield utils.exec("conda", ["install", "gz-sim8", "--channel", "conda-forge"]);
     });
 }
 exports.runWindows = runWindows;

--- a/dist/index.js
+++ b/dist/index.js
@@ -26307,14 +26307,20 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.runConda = exports.createCondaEnv = void 0;
+exports.runConda = exports.activateCondaEnv = exports.createCondaEnv = void 0;
 const utils = __importStar(__nccwpck_require__(1314));
-function createCondaEnv() {
+function createCondaEnv(envName) {
     return __awaiter(this, void 0, void 0, function* () {
-        return utils.exec("conda", ["create", "-n", "gz-env"]);
+        return utils.exec("conda", ["create", "-n"].concat([envName]));
     });
 }
 exports.createCondaEnv = createCondaEnv;
+function activateCondaEnv(envName) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return utils.exec("conda", ["activate"].concat([envName]));
+    });
+}
+exports.activateCondaEnv = activateCondaEnv;
 /**
  * Run conda install on a list of specified packages.
  *
@@ -26614,7 +26620,8 @@ function getLibVersion(gazeboDistro) {
 }
 function runWindows() {
     return __awaiter(this, void 0, void 0, function* () {
-        yield conda.createCondaEnv();
+        yield conda.createCondaEnv("gz-env");
+        yield conda.activateCondaEnv("gz-env");
         for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
             const version = yield getLibVersion(gazeboDistro);
             yield conda.runConda([`gz-sim${version}`]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -26309,12 +26309,24 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.runConda = exports.activateCondaEnv = exports.createCondaEnv = void 0;
 const utils = __importStar(__nccwpck_require__(1314));
+/**
+ * Create a conda environment
+ *
+ * @param envName
+ * @returns Promise<number> exit code
+ */
 function createCondaEnv(envName) {
     return __awaiter(this, void 0, void 0, function* () {
         return utils.exec("conda", ["create", "-n"].concat([envName]));
     });
 }
 exports.createCondaEnv = createCondaEnv;
+/**
+ * Activate a conda environment
+ *
+ * @param envName
+ * @returns Promise<number> exit code
+ */
 function activateCondaEnv(envName) {
     return __awaiter(this, void 0, void 0, function* () {
         return utils.exec("conda", ["activate"].concat([envName]));
@@ -26594,6 +26606,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.runWindows = void 0;
 const utils = __importStar(__nccwpck_require__(1314));
 const conda = __importStar(__nccwpck_require__(7725));
+// List of mapped Gazebo distro to gz-sim versions
 const validLibVersions = [
     {
         distro: "garden",
@@ -26604,6 +26617,12 @@ const validLibVersions = [
         libVersion: 8,
     },
 ];
+/**
+ * Get gz-sim library version
+ *
+ * @param gazeboDistro name of Gazebo distribution
+ * @returns gz-sim version
+ */
 function getLibVersion(gazeboDistro) {
     return __awaiter(this, void 0, void 0, function* () {
         let version;
@@ -26618,8 +26637,12 @@ function getLibVersion(gazeboDistro) {
         return version;
     });
 }
+/**
+ * Install Gazebo on a Windows worker
+ */
 function runWindows() {
     return __awaiter(this, void 0, void 0, function* () {
+        // Create and activate conda environment
         yield conda.createCondaEnv("gz-env");
         yield conda.activateCondaEnv("gz-env");
         for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -26307,32 +26307,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.runConda = exports.activateCondaEnv = exports.createCondaEnv = void 0;
+exports.runConda = void 0;
 const utils = __importStar(__nccwpck_require__(1314));
-/**
- * Create a conda environment
- *
- * @param envName
- * @returns Promise<number> exit code
- */
-function createCondaEnv(envName) {
-    return __awaiter(this, void 0, void 0, function* () {
-        return utils.exec("conda", ["create", "-n"].concat([envName]));
-    });
-}
-exports.createCondaEnv = createCondaEnv;
-/**
- * Activate a conda environment
- *
- * @param envName
- * @returns Promise<number> exit code
- */
-function activateCondaEnv(envName) {
-    return __awaiter(this, void 0, void 0, function* () {
-        return utils.exec("conda", ["activate"].concat([envName]));
-    });
-}
-exports.activateCondaEnv = activateCondaEnv;
 /**
  * Run conda install on a list of specified packages.
  *
@@ -26642,9 +26618,6 @@ function getLibVersion(gazeboDistro) {
  */
 function runWindows() {
     return __awaiter(this, void 0, void 0, function* () {
-        // Create and activate conda environment
-        yield conda.createCondaEnv("gz-env");
-        yield conda.activateCondaEnv("gz-env");
         for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
             const version = yield getLibVersion(gazeboDistro);
             yield conda.runConda([`gz-sim${version}`]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -26534,7 +26534,7 @@ function runWindows() {
             "--channel",
             "conda-forge",
         ]);
-        yield utils.exec("conda", ["install", "gz-sim8", "--channel", "conda-forge"]);
+        yield utils.exec("conda", ["install", "--channel", "conda-forge", "gz-sim8"]);
     });
 }
 exports.runWindows = runWindows;

--- a/dist/index.js
+++ b/dist/index.js
@@ -26269,6 +26269,68 @@ exports.runBrew = runBrew;
 
 /***/ }),
 
+/***/ 7725:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.runConda = exports.createCondaEnv = void 0;
+const utils = __importStar(__nccwpck_require__(1314));
+function createCondaEnv() {
+    return __awaiter(this, void 0, void 0, function* () {
+        return utils.exec("conda", ["create", "-n", "gz-env"]);
+    });
+}
+exports.createCondaEnv = createCondaEnv;
+/**
+ * Run conda install on a list of specified packages.
+ *
+ * @param   packages list of conda-forge packages to be installed
+ * @returns Promise<number> exit code
+ */
+function runConda(packages) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return utils.exec("conda", ["install", "--channel", "conda-forge"].concat(packages));
+    });
+}
+exports.runConda = runConda;
+
+
+/***/ }),
+
 /***/ 5467:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -26525,16 +26587,38 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.runWindows = void 0;
 const utils = __importStar(__nccwpck_require__(1314));
+const conda = __importStar(__nccwpck_require__(7725));
+const validLibVersions = [
+    {
+        distro: "garden",
+        libVersion: 7,
+    },
+    {
+        distro: "harmonic",
+        libVersion: 8,
+    },
+];
+function getLibVersion(gazeboDistro) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let version;
+        validLibVersions.forEach((obj) => {
+            if (obj.distro == gazeboDistro) {
+                version = obj.libVersion;
+            }
+        });
+        if (version === undefined) {
+            throw new Error(`No conda packages available for gz-${gazeboDistro}`);
+        }
+        return version;
+    });
+}
 function runWindows() {
     return __awaiter(this, void 0, void 0, function* () {
-        // await conda.runConda(["gz-sim8"]);
-        yield utils.exec("conda", [
-            "search",
-            "libgz-sim*",
-            "--channel",
-            "conda-forge",
-        ]);
-        yield utils.exec("conda", ["install", "--channel", "conda-forge", "gz-sim8"]);
+        yield conda.createCondaEnv();
+        for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
+            const version = yield getLibVersion(gazeboDistro);
+            yield conda.runConda([`gz-sim${version}`]);
+        }
     });
 }
 exports.runWindows = runWindows;

--- a/dist/index.js
+++ b/dist/index.js
@@ -26185,7 +26185,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.runAptGetInstall = void 0;
+exports.runAptGetInstall = runAptGetInstall;
 const utils = __importStar(__nccwpck_require__(1314));
 const aptCommandLine = [
     "DEBIAN_FRONTEND=noninteractive",
@@ -26208,7 +26208,6 @@ function runAptGetInstall(packages) {
         return utils.exec("sudo", aptCommandLine.concat(packages));
     });
 }
-exports.runAptGetInstall = runAptGetInstall;
 
 
 /***/ }),
@@ -26251,7 +26250,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.runBrew = void 0;
+exports.runBrew = runBrew;
 const utils = __importStar(__nccwpck_require__(1314));
 /**
  * Run brew install on a list of specified packages.
@@ -26264,7 +26263,6 @@ function runBrew(packages) {
         return utils.exec("brew", ["install"].concat(packages));
     });
 }
-exports.runBrew = runBrew;
 
 
 /***/ }),
@@ -26307,7 +26305,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.runConda = void 0;
+exports.runConda = runConda;
 const utils = __importStar(__nccwpck_require__(1314));
 /**
  * Run conda install on a list of specified packages.
@@ -26320,7 +26318,6 @@ function runConda(packages) {
         return utils.exec("conda", ["install", "--channel", "conda-forge"].concat(packages));
     });
 }
-exports.runConda = runConda;
 
 
 /***/ }),
@@ -26363,7 +26360,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.runLinux = void 0;
+exports.runLinux = runLinux;
 const core = __importStar(__nccwpck_require__(2186));
 const io = __importStar(__nccwpck_require__(7436));
 const apt = __importStar(__nccwpck_require__(4671));
@@ -26471,7 +26468,6 @@ function runLinux() {
         }
     });
 }
-exports.runLinux = runLinux;
 
 
 /***/ }),
@@ -26514,7 +26510,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.runMacOs = void 0;
+exports.runMacOs = runMacOs;
 const utils = __importStar(__nccwpck_require__(1314));
 const brew = __importStar(__nccwpck_require__(9586));
 /**
@@ -26536,7 +26532,6 @@ function runMacOs() {
         }
     });
 }
-exports.runMacOs = runMacOs;
 
 
 /***/ }),
@@ -26579,7 +26574,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.runWindows = void 0;
+exports.runWindows = runWindows;
 const utils = __importStar(__nccwpck_require__(1314));
 const conda = __importStar(__nccwpck_require__(7725));
 // List of mapped Gazebo distro to gz-sim versions
@@ -26594,7 +26589,9 @@ const validLibVersions = [
     },
 ];
 /**
- * Get gz-sim library version
+ * Get gz-sim library version corresponding to a gz-$collection
+ * since conda does not currently support the gz-$collection metapackages.
+ * See https://github.com/conda-forge/gz-sim-feedstock/issues/61
  *
  * @param gazeboDistro name of Gazebo distribution
  * @returns gz-sim version
@@ -26624,7 +26621,6 @@ function runWindows() {
         }
     });
 }
-exports.runWindows = runWindows;
 
 
 /***/ }),
@@ -26740,7 +26736,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.checkForUnstableAptRepos = exports.getRequiredGazeboDistributions = exports.validateDistro = exports.determineDistribCodename = exports.exec = void 0;
+exports.exec = exec;
+exports.determineDistribCodename = determineDistribCodename;
+exports.validateDistro = validateDistro;
+exports.getRequiredGazeboDistributions = getRequiredGazeboDistributions;
+exports.checkForUnstableAptRepos = checkForUnstableAptRepos;
 const actions_exec = __importStar(__nccwpck_require__(1514));
 const core = __importStar(__nccwpck_require__(2186));
 /**
@@ -26761,7 +26761,6 @@ function exec(commandLine, args, options, log_message) {
         });
     });
 }
-exports.exec = exec;
 /**
  * Determines the Ubuntu distribution codename.
  *
@@ -26783,7 +26782,6 @@ function determineDistribCodename() {
         return distribCodename;
     });
 }
-exports.determineDistribCodename = determineDistribCodename;
 // List of valid Gazebo distributions
 const validDistro = [
     "citadel",
@@ -26806,7 +26804,6 @@ function validateDistro(requiredGazeboDistributionsList) {
     }
     return true;
 }
-exports.validateDistro = validateDistro;
 /**
  * Gets the input of the Gazebo distributions to be installed and
  * validates them
@@ -26827,7 +26824,6 @@ function getRequiredGazeboDistributions() {
     }
     return requiredGazeboDistributionsList;
 }
-exports.getRequiredGazeboDistributions = getRequiredGazeboDistributions;
 /**
  * Check for unstable repository inputs
  *
@@ -26845,7 +26841,6 @@ function checkForUnstableAptRepos() {
     }
     return unstableRepos;
 }
-exports.checkForUnstableAptRepos = checkForUnstableAptRepos;
 
 
 /***/ }),

--- a/src/package_manager/conda.ts
+++ b/src/package_manager/conda.ts
@@ -1,5 +1,9 @@
 import * as utils from "../utils";
 
+export async function createCondaEnv(): Promise<number> {
+	return utils.exec("conda", ["create", "-n", "gz-env"]);
+}
+
 /**
  * Run conda install on a list of specified packages.
  *
@@ -9,6 +13,6 @@ import * as utils from "../utils";
 export async function runConda(packages: string[]): Promise<number> {
 	return utils.exec(
 		"conda",
-		["install"].concat(packages).concat("--channel conda-forge"),
+		["install", "--channel", "conda-forge"].concat(packages),
 	);
 }

--- a/src/package_manager/conda.ts
+++ b/src/package_manager/conda.ts
@@ -1,26 +1,6 @@
 import * as utils from "../utils";
 
 /**
- * Create a conda environment
- *
- * @param envName
- * @returns Promise<number> exit code
- */
-export async function createCondaEnv(envName: string): Promise<number> {
-	return utils.exec("conda", ["create", "-n"].concat([envName]));
-}
-
-/**
- * Activate a conda environment
- *
- * @param envName
- * @returns Promise<number> exit code
- */
-export async function activateCondaEnv(envName: string): Promise<number> {
-	return utils.exec("conda", ["activate"].concat([envName]));
-}
-
-/**
  * Run conda install on a list of specified packages.
  *
  * @param   packages list of conda-forge packages to be installed

--- a/src/package_manager/conda.ts
+++ b/src/package_manager/conda.ts
@@ -9,6 +9,6 @@ import * as utils from "../utils";
 export async function runConda(packages: string[]): Promise<number> {
 	return utils.exec(
 		"conda",
-		["install"].concat(packages).concat(["--channel conda-forge"]),
+		["install"].concat(packages).concat("--channel conda-forge"),
 	);
 }

--- a/src/package_manager/conda.ts
+++ b/src/package_manager/conda.ts
@@ -1,9 +1,21 @@
 import * as utils from "../utils";
 
+/**
+ * Create a conda environment
+ *
+ * @param envName
+ * @returns Promise<number> exit code
+ */
 export async function createCondaEnv(envName: string): Promise<number> {
 	return utils.exec("conda", ["create", "-n"].concat([envName]));
 }
 
+/**
+ * Activate a conda environment
+ *
+ * @param envName
+ * @returns Promise<number> exit code
+ */
 export async function activateCondaEnv(envName: string): Promise<number> {
 	return utils.exec("conda", ["activate"].concat([envName]));
 }

--- a/src/package_manager/conda.ts
+++ b/src/package_manager/conda.ts
@@ -1,0 +1,14 @@
+import * as utils from "../utils";
+
+/**
+ * Run conda install on a list of specified packages.
+ *
+ * @param   packages list of conda-forge packages to be installed
+ * @returns Promise<number> exit code
+ */
+export async function runConda(packages: string[]): Promise<number> {
+	return utils.exec(
+		"conda",
+		["install"].concat(packages).concat(["--channel conda-forge"]),
+	);
+}

--- a/src/package_manager/conda.ts
+++ b/src/package_manager/conda.ts
@@ -1,7 +1,11 @@
 import * as utils from "../utils";
 
-export async function createCondaEnv(): Promise<number> {
-	return utils.exec("conda", ["create", "-n", "gz-env"]);
+export async function createCondaEnv(envName: string): Promise<number> {
+	return utils.exec("conda", ["create", "-n"].concat([envName]));
+}
+
+export async function activateCondaEnv(envName: string): Promise<number> {
+	return utils.exec("conda", ["activate"].concat([envName]));
 }
 
 /**

--- a/src/setup-gazebo-windows.ts
+++ b/src/setup-gazebo-windows.ts
@@ -14,7 +14,9 @@ const validLibVersions: { distro: string; libVersion: number }[] = [
 ];
 
 /**
- * Get gz-sim library version
+ * Get gz-sim library version corresponding to a gz-$collection
+ * since conda does not currently support the gz-$collection metapackages.
+ * See https://github.com/conda-forge/gz-sim-feedstock/issues/61
  *
  * @param gazeboDistro name of Gazebo distribution
  * @returns gz-sim version

--- a/src/setup-gazebo-windows.ts
+++ b/src/setup-gazebo-windows.ts
@@ -1,6 +1,7 @@
 import * as utils from "./utils";
 import * as conda from "./package_manager/conda";
 
+// List of mapped Gazebo distro to gz-sim versions
 const validLibVersions: { distro: string; libVersion: number }[] = [
 	{
 		distro: "garden",
@@ -12,6 +13,12 @@ const validLibVersions: { distro: string; libVersion: number }[] = [
 	},
 ];
 
+/**
+ * Get gz-sim library version
+ *
+ * @param gazeboDistro name of Gazebo distribution
+ * @returns gz-sim version
+ */
 async function getLibVersion(gazeboDistro: string): Promise<number> {
 	let version: number | undefined;
 	validLibVersions.forEach((obj) => {
@@ -25,7 +32,11 @@ async function getLibVersion(gazeboDistro: string): Promise<number> {
 	return version;
 }
 
+/**
+ * Install Gazebo on a Windows worker
+ */
 export async function runWindows(): Promise<void> {
+	// Create and activate conda environment
 	await conda.createCondaEnv("gz-env");
 	await conda.activateCondaEnv("gz-env");
 

--- a/src/setup-gazebo-windows.ts
+++ b/src/setup-gazebo-windows.ts
@@ -26,7 +26,8 @@ async function getLibVersion(gazeboDistro: string): Promise<number> {
 }
 
 export async function runWindows(): Promise<void> {
-	await conda.createCondaEnv();
+	await conda.createCondaEnv("gz-env");
+	await conda.activateCondaEnv("gz-env");
 
 	for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
 		const version = await getLibVersion(gazeboDistro);

--- a/src/setup-gazebo-windows.ts
+++ b/src/setup-gazebo-windows.ts
@@ -36,10 +36,6 @@ async function getLibVersion(gazeboDistro: string): Promise<number> {
  * Install Gazebo on a Windows worker
  */
 export async function runWindows(): Promise<void> {
-	// Create and activate conda environment
-	await conda.createCondaEnv("gz-env");
-	await conda.activateCondaEnv("gz-env");
-
 	for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
 		const version = await getLibVersion(gazeboDistro);
 		await conda.runConda([`gz-sim${version}`]);

--- a/src/setup-gazebo-windows.ts
+++ b/src/setup-gazebo-windows.ts
@@ -1,5 +1,12 @@
-import * as conda from "./package_manager/conda";
+import * as utils from "./utils";
 
 export async function runWindows(): Promise<void> {
-	await conda.runConda(["gz-sim8"]);
+	// await conda.runConda(["gz-sim8"]);
+	await utils.exec("conda", [
+		"search",
+		"libgz-sim*",
+		"--channel",
+		"conda-forge",
+	]);
+	await utils.exec("conda", ["install", "gz-sim8", "--channel", "conda-forge"]);
 }

--- a/src/setup-gazebo-windows.ts
+++ b/src/setup-gazebo-windows.ts
@@ -1,0 +1,5 @@
+import * as conda from "./package_manager/conda";
+
+export async function runWindows(): Promise<void> {
+	await conda.runConda(["gz-sim8"]);
+}

--- a/src/setup-gazebo-windows.ts
+++ b/src/setup-gazebo-windows.ts
@@ -1,12 +1,35 @@
 import * as utils from "./utils";
+import * as conda from "./package_manager/conda";
+
+const validLibVersions: { distro: string; libVersion: number }[] = [
+	{
+		distro: "garden",
+		libVersion: 7,
+	},
+	{
+		distro: "harmonic",
+		libVersion: 8,
+	},
+];
+
+async function getLibVersion(gazeboDistro: string): Promise<number> {
+	let version: number | undefined;
+	validLibVersions.forEach((obj) => {
+		if (obj.distro == gazeboDistro) {
+			version = obj.libVersion;
+		}
+	});
+	if (version === undefined) {
+		throw new Error(`No conda packages available for gz-${gazeboDistro}`);
+	}
+	return version;
+}
 
 export async function runWindows(): Promise<void> {
-	// await conda.runConda(["gz-sim8"]);
-	await utils.exec("conda", [
-		"search",
-		"libgz-sim*",
-		"--channel",
-		"conda-forge",
-	]);
-	await utils.exec("conda", ["install", "--channel", "conda-forge", "gz-sim8"]);
+	await conda.createCondaEnv();
+
+	for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
+		const version = await getLibVersion(gazeboDistro);
+		await conda.runConda([`gz-sim${version}`]);
+	}
 }

--- a/src/setup-gazebo-windows.ts
+++ b/src/setup-gazebo-windows.ts
@@ -8,5 +8,5 @@ export async function runWindows(): Promise<void> {
 		"--channel",
 		"conda-forge",
 	]);
-	await utils.exec("conda", ["install", "gz-sim8", "--channel", "conda-forge"]);
+	await utils.exec("conda", ["install", "--channel", "conda-forge", "gz-sim8"]);
 }

--- a/src/setup-gazebo.ts
+++ b/src/setup-gazebo.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import * as linux from "./setup-gazebo-linux";
 import * as macOs from "./setup-gazebo-macos";
+import * as windows from "./setup-gazebo-windows";
 
 async function run() {
 	try {
@@ -9,6 +10,8 @@ async function run() {
 			macOs.runMacOs();
 		} else if (platform === "linux") {
 			linux.runLinux();
+		} else if (platform === "win32") {
+			windows.runWindows();
 		} else {
 			throw new Error(`Unsupported platform ${platform}`);
 		}


### PR DESCRIPTION
Closes #27 

## Summary

This PR implements functionality for the GitHub action to run on Windows runner. (Following the [official installation documentation](https://gazebosim.org/docs/harmonic/install_windows))
- The action installs a specific version of the `gz-sim` library using the information from [collections](https://github.com/gazebo-tooling/gazebodistro).
- It needs another GitHub action [`setup-miniconda`](https://github.com/marketplace/actions/setup-miniconda) to install Miniconda
- Currently, it only supports the install of `harmonic` and `garden`.
- A sample job has been added to the workflow to test the action.
- README and tests have been updated.