### PR TITLE
Testing the action on GitHub-hosted ubuntu runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,16 +14,14 @@ defaults:
 jobs:
   test_action_linux:
     name: 'Run unit test on action'
-    runs-on: ubuntu-latest
-    container:
-      image: ${{ matrix.docker_image }}
+    runs-on: ${{ matrix.ubuntu_distro }}
     strategy:
       fail-fast: false
       matrix:
-        docker_image:
-          - ubuntu:focal
-          - ubuntu:jammy
-          - ubuntu:noble
+        ubuntu_distro:
+          - ubuntu-20.04
+          - ubuntu-22.04
+          - ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2
@@ -33,6 +31,56 @@ jobs:
 
   test_gazebo_install_ubuntu:
     name: 'Check installation of Gazebo on Ubuntu'
+    runs-on: ${{ matrix.ubuntu_distro }}
+    strategy:
+      fail-fast: false
+      matrix:
+        gazebo_distribution:
+          - citadel
+          - fortress
+          - garden
+          - harmonic
+        include:
+          # Gazebo Citadel (Dec 2019 - Dec 2024)
+          - ubuntu_distro: ubuntu-20.04
+            gazebo_distribution: citadel
+
+          # Gazebo Fortress (Sep 2021 - Sep 2026)
+          - ubuntu_distro: ubuntu-20.04
+            gazebo_distribution: fortress
+
+          # Gazebo Garden (Sep 2022 - Nov 2024)
+          - ubuntu_distro: ubuntu-20.04
+            gazebo_distribution: garden
+
+          # Gazebo Harmonic (Sep 2023 - Sep 2028)
+          - ubuntu_distro: ubuntu-22.04
+            gazebo_distribution: harmonic
+
+          - ubuntu_distro: ubuntu-24.04
+            gazebo_distribution: harmonic
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: '20.x'
+      - name: 'Check Gazebo installation on Ubuntu runner'
+        uses: ./
+        with:
+          required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
+      - name: 'Test Gazebo installation'
+        run: |
+          if command -v ign > /dev/null; then
+            ign gazebo --versions
+          elif command -v gz > /dev/null; then
+            gz sim --versions
+          else
+            echo "Neither ign nor gz command found"
+            exit 1
+          fi
+
+  test_gazebo_install_ubuntu_docker:
+    name: 'Check installation of Gazebo on Ubuntu inside a container'
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.docker_image }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,28 +150,6 @@ jobs:
             exit 1
           fi
 
-  test_gazebo_install_ubuntu_prerelease:
-    name: 'Install Gazebo pre-release on Ubuntu GitHub runner'
-    runs-on: ${{ matrix.ubuntu_distribution }}
-    strategy:
-      fail-fast: false
-      matrix:
-        ubuntu_distribution:
-          - ubuntu-22.04
-          - ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.0.3
-        with:
-          node-version: '20.x'
-      - name: 'Check Gazebo installation on Ubuntu runner'
-        uses: ./
-        with:
-          required-gazebo-distributions: 'harmonic'
-          use-gazebo-prerelease: 'true'
-      - name: 'Test Gazebo installation'
-        run: 'gz sim --versions'
-
   test_gazebo_install_ubuntu_prerelease_docker:
     name: 'Install Gazebo pre-release on Ubuntu docker'
     runs-on: ubuntu-latest
@@ -193,22 +171,6 @@ jobs:
         with:
           required-gazebo-distributions: 'harmonic'
           use-gazebo-prerelease: 'true'
-      - name: 'Test Gazebo installation'
-        run: 'gz sim --versions'
-
-  test_gazebo_install_ubuntu_nightly:
-    name: 'Install Gazebo nightly on Ubuntu GitHub runner'
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.0.3
-        with:
-          node-version: '20.x'
-      - name: 'Check Gazebo installation on Ubuntu runner'
-        uses: ./
-        with:
-          required-gazebo-distributions: 'ionic'
-          use-gazebo-nightly: 'true'
       - name: 'Test Gazebo installation'
         run: 'gz sim --versions'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ defaults:
 jobs:
   test_action_linux:
     name: 'Run unit test on action'
-    runs-on: ${{ matrix.ubuntu_distro }}
+    runs-on: ${{ matrix.ubuntu_distribution }}
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_distro:
+        ubuntu_distribution:
           - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
@@ -31,7 +31,7 @@ jobs:
 
   test_gazebo_install_ubuntu:
     name: 'Check installation of Gazebo on Ubuntu'
-    runs-on: ${{ matrix.ubuntu_distro }}
+    runs-on: ${{ matrix.ubuntu_distribution }}
     strategy:
       fail-fast: false
       matrix:
@@ -42,22 +42,22 @@ jobs:
           - harmonic
         include:
           # Gazebo Citadel (Dec 2019 - Dec 2024)
-          - ubuntu_distro: ubuntu-20.04
+          - ubuntu_distribution: ubuntu-20.04
             gazebo_distribution: citadel
 
           # Gazebo Fortress (Sep 2021 - Sep 2026)
-          - ubuntu_distro: ubuntu-20.04
+          - ubuntu_distribution: ubuntu-20.04
             gazebo_distribution: fortress
 
           # Gazebo Garden (Sep 2022 - Nov 2024)
-          - ubuntu_distro: ubuntu-20.04
+          - ubuntu_distribution: ubuntu-20.04
             gazebo_distribution: garden
 
           # Gazebo Harmonic (Sep 2023 - Sep 2028)
-          - ubuntu_distro: ubuntu-22.04
+          - ubuntu_distribution: ubuntu-22.04
             gazebo_distribution: harmonic
 
-          - ubuntu_distro: ubuntu-24.04
+          - ubuntu_distribution: ubuntu-24.04
             gazebo_distribution: harmonic
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash
 jobs:
   test_action_linux:
-    name: 'Run unit test on action on GitHub runners'
+    name: 'Unit testing action on GitHub runners'
     runs-on: ${{ matrix.ubuntu_distribution }}
     strategy:
       fail-fast: false
@@ -30,7 +30,7 @@ jobs:
       - run: .github/workflows/build-and-test.sh
 
   test_action_linux_docker:
-    name: 'Run unit test on action in a docker container'
+    name: 'Unit testing action in a docker container'
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.docker_image }}
@@ -49,7 +49,7 @@ jobs:
       - run: .github/workflows/build-and-test.sh
 
   test_gazebo_install_ubuntu:
-    name: 'Check installation of Gazebo on Ubuntu GitHub runner'
+    name: 'Install Gazebo on Ubuntu GitHub runner'
     runs-on: ${{ matrix.ubuntu_distribution }}
     strategy:
       fail-fast: false
@@ -99,7 +99,7 @@ jobs:
           fi
 
   test_gazebo_install_ubuntu_docker:
-    name: 'Check installation of Gazebo on Ubuntu in a docker container'
+    name: 'Install Gazebo on Ubuntu docker'
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.docker_image }}
@@ -151,7 +151,7 @@ jobs:
           fi
 
   test_gazebo_install_ubuntu_prerelease:
-    name: 'Check installation of Gazebo pre-release binary on Ubuntu GitHub runner'
+    name: 'Install Gazebo pre-release on Ubuntu GitHub runner'
     runs-on: ${{ matrix.ubuntu_distribution }}
     strategy:
       fail-fast: false
@@ -173,7 +173,7 @@ jobs:
         run: 'gz sim --versions'
 
   test_gazebo_install_ubuntu_prerelease_docker:
-    name: 'Check installation of Gazebo pre-release binary on Ubuntu in a docker container'
+    name: 'Install Gazebo pre-release on Ubuntu docker'
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.docker_image }}
@@ -197,7 +197,7 @@ jobs:
         run: 'gz sim --versions'
 
   test_gazebo_install_ubuntu_nightly:
-    name: 'Check installation of Gazebo nightly binary on Ubuntu GitHub runner'
+    name: 'Install Gazebo nightly on Ubuntu GitHub runner'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -213,7 +213,7 @@ jobs:
         run: 'gz sim --versions'
 
   test_gazebo_install_ubuntu_nightly_docker:
-    name: 'Check installation of Gazebo nightly binary on Ubuntu in a docker container'
+    name: 'Install Gazebo nightly on Ubuntu docker'
     runs-on: ubuntu-latest
     container:
       image: ubuntu:noble
@@ -231,7 +231,7 @@ jobs:
         run: 'gz sim --versions'
 
   test_gazebo_install_macos:
-    name: 'Check installation of Gazebo on MacOS'
+    name: 'Install Gazebo on MacOS'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -255,7 +255,7 @@ jobs:
         run: 'gz sim --versions'
 
   test_gazebo_install_windows:
-    name: 'Check installation of Gazebo on Windows'
+    name: 'Install Gazebo on Windows'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash
 jobs:
   test_action_linux:
-    name: 'Run unit test on action'
+    name: 'Run unit test on action on GitHub runners'
     runs-on: ${{ matrix.ubuntu_distribution }}
     strategy:
       fail-fast: false
@@ -29,8 +29,27 @@ jobs:
           node-version: '20.x'
       - run: .github/workflows/build-and-test.sh
 
+  test_action_linux_docker:
+    name: 'Run unit test on action in a docker container'
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.docker_image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        docker_image:
+          - ubuntu:focal
+          - ubuntu:jammy
+          - ubuntu:noble
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: '20.x'
+      - run: .github/workflows/build-and-test.sh
+
   test_gazebo_install_ubuntu:
-    name: 'Check installation of Gazebo on Ubuntu'
+    name: 'Check installation of Gazebo on Ubuntu GitHub runner'
     runs-on: ${{ matrix.ubuntu_distribution }}
     strategy:
       fail-fast: false
@@ -80,7 +99,7 @@ jobs:
           fi
 
   test_gazebo_install_ubuntu_docker:
-    name: 'Check installation of Gazebo on Ubuntu inside a container'
+    name: 'Check installation of Gazebo on Ubuntu in a docker container'
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.docker_image }}
@@ -113,7 +132,7 @@ jobs:
             gazebo_distribution: harmonic
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.x'
       - name: 'Check Gazebo installation on Ubuntu runner'
@@ -132,7 +151,29 @@ jobs:
           fi
 
   test_gazebo_install_ubuntu_prerelease:
-    name: 'Check installation of Gazebo pre-release binary on Ubuntu'
+    name: 'Check installation of Gazebo pre-release binary on Ubuntu GitHub runner'
+    runs-on: ${{ matrix.ubuntu_distribution }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu_distribution:
+          - ubuntu-22.04
+          - ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: '20.x'
+      - name: 'Check Gazebo installation on Ubuntu runner'
+        uses: ./
+        with:
+          required-gazebo-distributions: 'harmonic'
+          use-gazebo-prerelease: 'true'
+      - name: 'Test Gazebo installation'
+        run: 'gz sim --versions'
+
+  test_gazebo_install_ubuntu_prerelease_docker:
+    name: 'Check installation of Gazebo pre-release binary on Ubuntu in a docker container'
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.docker_image }}
@@ -144,7 +185,7 @@ jobs:
           - ubuntu:noble
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.x'
       - name: 'Check Gazebo installation on Ubuntu runner'
@@ -156,13 +197,29 @@ jobs:
         run: 'gz sim --versions'
 
   test_gazebo_install_ubuntu_nightly:
-    name: 'Check installation of Gazebo nightly binary on Ubuntu'
+    name: 'Check installation of Gazebo nightly binary on Ubuntu GitHub runner'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: '20.x'
+      - name: 'Check Gazebo installation on Ubuntu runner'
+        uses: ./
+        with:
+          required-gazebo-distributions: 'ionic'
+          use-gazebo-nightly: 'true'
+      - name: 'Test Gazebo installation'
+        run: 'gz sim --versions'
+
+  test_gazebo_install_ubuntu_nightly_docker:
+    name: 'Check installation of Gazebo nightly binary on Ubuntu in a docker container'
     runs-on: ubuntu-latest
     container:
       image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.x'
       - name: 'Check Gazebo installation on Ubuntu runner'
@@ -187,7 +244,7 @@ jobs:
           - macos-13
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.x'
       - name: 'Check Gazebo installation on MacOS runner'
@@ -202,7 +259,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.x'
       - uses: conda-incubator/setup-miniconda@v3

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The `setup-gazebo` GitHub action can be run using GitHub-hosted Ubuntu runners o
 
 This workflow shows how to spawn a job to install Gazebo on an Ubuntu distribution. The action needs an input in the `required-gazebo-distributions` field.
 
-- *Using GitHub-hosted runners*
+- *Default: Using GitHub-hosted runners systems*
 
   The following code snippet shows the installation of Gazebo Harmonic on Ubuntu Noble.
 
@@ -115,7 +115,7 @@ This workflow shows how to spawn a job to install Gazebo on an Ubuntu distributi
 
 This workflow shows how to spawn one job per Gazebo release and iterates over all specified Gazebo and Ubuntu combinations. It is done by defining a `matrix` to iterate over jobs.
 
-- *Using GitHub-hosted runners*
+- *Default: Using GitHub-hosted runners systems*
 
 ```yaml
   jobs:
@@ -222,29 +222,6 @@ This workflow shows how to spawn one job per Gazebo release and iterates over al
 #### Using pre-release and/or nightly Gazebo binaries
 
 This workflow shows how to use binaries from [pre-release] or [nightly] Gazebo repositories instead of the stable repository by setting the `use-gazebo-prerelease` or `use-gazebo-nightly` to `true`.
-
-- *Using GitHub-hosted runners*
-
-```yaml
-  jobs:
-    test_gazebo:
-        runs-on: ubuntu-24.04
-        steps:
-          - uses: actions/checkout@v4
-          - uses: actions/setup-node@v4.0.2
-            with:
-              node-version: '20.x'
-          - name: 'Check Gazebo installation on Ubuntu runner'
-            uses: gazebo-tooling/setup-gazebo@<full_commit_hash>
-            with:
-              required-gazebo-distributions: 'harmonic'
-              use-gazebo-prerelease: 'true'
-              use-gazebo-nightly: 'true'
-          - name: 'Test Gazebo installation'
-            run: 'gz sim --versions'
-```
-
-- *Using Ubuntu docker containers*
 
 ```yaml
   jobs:


### PR DESCRIPTION
Closes #38 

## Summary

The PR adds jobs to `test.yml` to run the action on GitHub ubuntu runners. 

Updated the README with instructions. Also added a note about the `ubuntu-24.04` being a beta version.