### PR TITLE
Installing ROS 2 and Gazebo side-by-side along with `ros_gz`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,3 +256,21 @@ jobs:
         run: |
           conda activate
           gz sim --versions
+
+  test_install_ros_gz:
+    name: 'Install ros_gz side-by-side Gazebo'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: '20.x'
+      - name: 'Install ROS 2 Jazzy'
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
+      - name: 'Install Gazebo with ros_gz'
+        uses: ./
+        with:
+          required-gazebo-distributions: 'harmonic'
+          install-ros-gz: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -272,9 +272,9 @@ jobs:
       - name: 'Install ROS 2 Iron and Rolling'
         uses: ros-tooling/setup-ros@v0.7
         with:
-          required-ros-distributions: '$ROS_DISTROS'
+          required-ros-distributions: $ROS_DISTROS
       - name: 'Install Gazebo with ros_gz'
         uses: ./
         with:
           required-gazebo-distributions: 'harmonic'
-          install-ros-gz: '$ROS_DISTROS'
+          install-ros-gz: $ROS_DISTROS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,7 @@ jobs:
           gz sim --versions
 
   test_install_ros_gz:
-    name: 'Install ros_gz side-by-side Gazebo'
+    name: 'Install ROS 2 side-by-side Gazebo'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -268,7 +268,7 @@ jobs:
       - name: 'Install ROS 2 Jazzy'
         uses: ros-tooling/setup-ros@v0.7
         with:
-          required-ros-distributions: jazzy
+          required-ros-distributions: 'iron jazzy'
       - name: 'Install Gazebo with ros_gz'
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,3 +276,15 @@ jobs:
         with:
           required-gazebo-distributions: 'harmonic'
           install-ros-gz: 'rolling iron'
+      - name: Test Gazebo installation
+        run: |
+          gz sim --versions
+      - name: Test Rolling ros_gz installation
+        run: |
+          source /opt/ros/rolling/setup.bash
+          ros2 pkg list | grep ros_gz
+      - name: Test Iron ros_gz installation
+        run: |
+          source /opt/ros/iron/setup.bash
+          ros2 pkg list | grep ros_gz
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,8 +262,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:jammy
-    env:
-      ROS_DISTROS: iron rolling
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.3
@@ -272,9 +270,9 @@ jobs:
       - name: 'Install ROS 2 Iron and Rolling'
         uses: ros-tooling/setup-ros@v0.7
         with:
-          required-ros-distributions: $ROS_DISTROS
+          required-ros-distributions: 'rolling iron'
       - name: 'Install Gazebo with ros_gz'
         uses: ./
         with:
           required-gazebo-distributions: 'harmonic'
-          install-ros-gz: $ROS_DISTROS
+          install-ros-gz: 'rolling iron'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,7 +263,7 @@ jobs:
     container:
       image: ubuntu:jammy
     env:
-      ROS_DISTROS: 'iron rolling'
+      ROS_DISTROS: iron rolling
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.3
@@ -272,9 +272,9 @@ jobs:
       - name: 'Install ROS 2 Iron and Rolling'
         uses: ros-tooling/setup-ros@v0.7
         with:
-          required-ros-distributions: $ROS_DISTROS
+          required-ros-distributions: '$ROS_DISTROS'
       - name: 'Install Gazebo with ros_gz'
         uses: ./
         with:
           required-gazebo-distributions: 'harmonic'
-          install-ros-gz: $ROS_DISTROS
+          install-ros-gz: '$ROS_DISTROS'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,18 +259,22 @@ jobs:
 
   test_install_ros_gz:
     name: 'Install ROS 2 side-by-side Gazebo'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:jammy
+    env:
+      ROS_DISTROS: 'iron rolling'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.x'
-      - name: 'Install ROS 2 Jazzy'
+      - name: 'Install ROS 2 Iron and Rolling'
         uses: ros-tooling/setup-ros@v0.7
         with:
-          required-ros-distributions: 'iron jazzy'
+          required-ros-distributions: $ROS_DISTROS
       - name: 'Install Gazebo with ros_gz'
         uses: ./
         with:
           required-gazebo-distributions: 'harmonic'
-          install-ros-gz: 'jazzy iron'
+          install-ros-gz: $ROS_DISTROS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -257,10 +257,10 @@ jobs:
           conda activate
           gz sim --versions
 
-  test_install_ros_gz:
-    name: 'Install ROS 2 and Gazebo side-by-side'
+  test_install_ros_gz_unofficial:
+    name: 'Install Iron and Harmonic side-by-side'
     env:
-      ROS_DISTROS: 'rolling iron'
+      ROS_DISTROS: 'iron'
     runs-on: ubuntu-latest
     container:
       image: ubuntu:jammy
@@ -269,24 +269,44 @@ jobs:
       - uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.x'
-      - name: 'Install ROS 2 Iron and Rolling'
+      - name: 'Install ROS 2 Iron'
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: ${{ env.ROS_DISTROS }}
+      - name: 'Install Gazebo Harmonic with ros_gz'
+        uses: ./
+        with:
+          required-gazebo-distributions: 'harmonic'
+          install-ros-gz: ${{ env.ROS_DISTROS }}
+      - name: Test Iron ros_gz installation
+        run: |
+          source /opt/ros/iron/setup.bash
+          ros2 pkg list | grep ros_gz
+          gz sim --version | grep 'version 8.[0-9*].[0-9*]'
+
+  test_install_ros_gz_official:
+    name: 'Install Humble and Fortress side-by-side'
+    env:
+      ROS_DISTROS: 'humble'
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:jammy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: '20.x'
+      - name: 'Install ROS 2 Humble'
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ env.ROS_DISTROS }}
       - name: 'Install Gazebo with ros_gz'
         uses: ./
         with:
-          required-gazebo-distributions: 'harmonic'
+          required-gazebo-distributions: 'fortress'
           install-ros-gz: ${{ env.ROS_DISTROS }}
-      - name: Test Gazebo installation
+      - name: Test Humble ros_gz installation
         run: |
-          gz sim --versions
-      - name: Test Rolling ros_gz installation
-        run: |
-          source /opt/ros/rolling/setup.bash
+          source /opt/ros/humble/setup.bash
           ros2 pkg list | grep ros_gz
-      - name: Test Iron ros_gz installation
-        run: |
-          source /opt/ros/iron/setup.bash
-          ros2 pkg list | grep ros_gz
-
+          gz sim --version | grep 'version 8.[0-9*].[0-9*]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,7 @@ jobs:
           gz sim --versions
 
   test_install_ros_gz:
-    name: 'Install ROS 2 side-by-side Gazebo'
+    name: 'Install ROS 2 and Gazebo side-by-side'
     runs-on: ubuntu-latest
     container:
       image: ubuntu:jammy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,4 +273,4 @@ jobs:
         uses: ./
         with:
           required-gazebo-distributions: 'harmonic'
-          install-ros-gz: 'true'
+          install-ros-gz: 'jazzy iron'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,6 +259,8 @@ jobs:
 
   test_install_ros_gz:
     name: 'Install ROS 2 and Gazebo side-by-side'
+    env:
+      ROS_DISTROS: 'rolling iron'
     runs-on: ubuntu-latest
     container:
       image: ubuntu:jammy
@@ -270,12 +272,12 @@ jobs:
       - name: 'Install ROS 2 Iron and Rolling'
         uses: ros-tooling/setup-ros@v0.7
         with:
-          required-ros-distributions: 'rolling iron'
+          required-ros-distributions: ${{ env.ROS_DISTROS }}
       - name: 'Install Gazebo with ros_gz'
         uses: ./
         with:
           required-gazebo-distributions: 'harmonic'
-          install-ros-gz: 'rolling iron'
+          install-ros-gz: ${{ env.ROS_DISTROS }}
       - name: Test Gazebo installation
         run: |
           gz sim --versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -309,4 +309,4 @@ jobs:
         run: |
           source /opt/ros/humble/setup.bash
           ros2 pkg list | grep ros_gz
-          gz sim --version | grep 'version 8.[0-9*].[0-9*]'
+          ign gazebo --version | grep 'version 6.*'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This action sets up a Gazebo environment.
         1. [Setting up worker and installing a compatible Gazebo and Ubuntu combination](#Setting-up-worker-and-installing-a-compatible-Gazebo-and-Ubuntu-combination)
         1. [Iterating on all Gazebo and Ubuntu combinations](#Iterating-on-all-gazebo-ubuntu-combinations)
         1. [Using pre-release and/or nightly Gazebo binaries](#Using-pre-release-and/or-nightly-Gazebo-binaries)
-        1. [Installing ROS 2 and Gazebo side-by-side along with `ros-gz`](#Installing-ROS-2-and-Gazebo-side-by-side-along-with-ros-gz)
+        1. [Installing ROS 2 and Gazebo side-by-side along with `ros_gz`](#Installing-ROS-2-and-Gazebo-side-by-side-along-with-ros_gz)
     2. [macOS](#macOS)
         1. [Setting up worker to install Gazebo on macOS](#Setting-up-worker-to-install-Gazebo-on-macOS)
     3. [Windows](#Windows)
@@ -246,7 +246,7 @@ This workflow shows how to use binaries from [pre-release] or [nightly] Gazebo r
             run: 'gz sim --versions'
 ```
 
-#### Installing ROS 2 and Gazebo side-by-side along with `ros-gz`
+#### Installing ROS 2 and Gazebo side-by-side along with `ros_gz`
 
 This workflow shows how to install ROS 2 using the GitHub action `ros-tooling/setup-ros` along with Gazebo installed using `setup-gazebo`. The `ros-gz` package can be installed by setting the input parameter `install-ros-gz` to the required ROS 2 distributions.
 
@@ -256,6 +256,8 @@ This workflow shows how to install ROS 2 using the GitHub action `ros-tooling/se
       runs-on: ubuntu-latest
       container:
         image: ubuntu:jammy
+      env:
+        ROS_DISTROS: 'rolling iron'
       steps:
         - uses: actions/checkout@v4
         - uses: actions/setup-node@v4.0.3
@@ -264,12 +266,23 @@ This workflow shows how to install ROS 2 using the GitHub action `ros-tooling/se
         - name: 'Install ROS 2 Iron and Rolling'
           uses: ros-tooling/setup-ros@v0.7
           with:
-            required-ros-distributions: 'rolling iron'
+            required-ros-distributions: ${{ env.ROS_DISTROS }}
         - name: 'Install Gazebo with ros_gz'
           uses: gazebo-tooling/setup-gazebo@v0.1.0
           with:
             required-gazebo-distributions: 'harmonic'
-            install-ros-gz: 'rolling iron'
+            install-ros-gz: ${{ env.ROS_DISTROS }}
+        - name: Test Gazebo installation
+          run: |
+            gz sim --versions
+        - name: Test Rolling ros_gz installation
+          run: |
+            source /opt/ros/rolling/setup.bash
+            ros2 pkg list | grep ros_gz
+        - name: Test Iron ros_gz installation
+          run: |
+            source /opt/ros/iron/setup.bash
+            ros2 pkg list | grep ros_gz
 ```
 
 ### macOS

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The `setup-gazebo` GitHub Action sets up an environment to install a Gazebo rele
 - `required-gazebo-distributions`: A **required** parameter that specifies the Gazebo distribution to be installed.
 - `use-gazebo-prerelease`: An **optional** parameter to install pre-release binaries from OSRF repository.
 - `use-gazebo-nightly`: An **optional** parameter to install nightly binaries from OSRF repository.
-- `install-ros-gz`: An **optional** parameter to install the ROS 2 Gazebo bridge (`ros_gz`).
+- `install-ros-gz`: An **optional** parameter to install the ROS 2 Gazebo bridge (`ros_gz`). This will require a previous ROS installation which can be done using the [`setup-ros`](https://github.com/ros-tooling/setup-ros) GitHub action. Installation of the `ros_gz` bridge supports the ROS official and ROS non-official (from packages.osrfoundation.org) variants following the [Installing Gazebo with ROS](https://gazebosim.org/docs/ionic/ros_installation/#summary-of-compatible-ros-and-gazebo-combinations) documentation.
 
 ## Supported platforms
 

--- a/README.md
+++ b/README.md
@@ -253,36 +253,31 @@ This workflow shows how to install ROS 2 using the GitHub action `ros-tooling/se
 ```yaml
   jobs:
     test_gazebo:
-      runs-on: ubuntu-latest
-      container:
-        image: ubuntu:jammy
-      env:
-        ROS_DISTROS: 'rolling iron'
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-node@v4.0.3
-          with:
-            node-version: '20.x'
-        - name: 'Install ROS 2 Iron and Rolling'
-          uses: ros-tooling/setup-ros@v0.7
-          with:
-            required-ros-distributions: ${{ env.ROS_DISTROS }}
-        - name: 'Install Gazebo with ros_gz'
-          uses: gazebo-tooling/setup-gazebo@v0.1.0
-          with:
-            required-gazebo-distributions: 'harmonic'
-            install-ros-gz: ${{ env.ROS_DISTROS }}
-        - name: Test Gazebo installation
-          run: |
-            gz sim --versions
-        - name: Test Rolling ros_gz installation
-          run: |
-            source /opt/ros/rolling/setup.bash
-            ros2 pkg list | grep ros_gz
-        - name: Test Iron ros_gz installation
-          run: |
-            source /opt/ros/iron/setup.bash
-            ros2 pkg list | grep ros_gz
+    name: 'Install Iron and Harmonic side-by-side'
+    env:
+      ROS_DISTROS: 'iron'
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:jammy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: '20.x'
+      - name: 'Install ROS 2 Iron'
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: ${{ env.ROS_DISTROS }}
+      - name: 'Install Gazebo Harmonic with ros_gz'
+        uses: gazebo-tooling/setup-gazebo@v0.1.0
+        with:
+          required-gazebo-distributions: 'harmonic'
+          install-ros-gz: ${{ env.ROS_DISTROS }}
+      - name: Test Iron ros_gz installation
+        run: |
+          source /opt/ros/iron/setup.bash
+          ros2 pkg list | grep ros_gz
+          gz sim --version | grep 'version 8.[0-9*].[0-9*]'
 ```
 
 ### macOS

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This action sets up a Gazebo environment.
         1. [Setting up worker and installing a compatible Gazebo and Ubuntu combination](#Setting-up-worker-and-installing-a-compatible-Gazebo-and-Ubuntu-combination)
         1. [Iterating on all Gazebo and Ubuntu combinations](#Iterating-on-all-gazebo-ubuntu-combinations)
         1. [Using pre-release and/or nightly Gazebo binaries](#Using-pre-release-and/or-nightly-Gazebo-binaries)
+        1. [Installing ROS 2 and Gazebo side-by-side along with `ros-gz`](#Installing-ROS-2-and-Gazebo-side-by-side-along-with-ros-gz)
     2. [macOS](#macOS)
         1. [Setting up worker to install Gazebo on macOS](#Setting-up-worker-to-install-Gazebo-on-macOS)
     3. [Windows](#Windows)
@@ -243,6 +244,32 @@ This workflow shows how to use binaries from [pre-release] or [nightly] Gazebo r
               use-gazebo-nightly: 'true'
           - name: 'Test Gazebo installation'
             run: 'gz sim --versions'
+```
+
+#### Installing ROS 2 and Gazebo side-by-side along with `ros-gz`
+
+This workflow shows how to install ROS 2 using the GitHub action `ros-tooling/setup-ros` along with Gazebo installed using `setup-gazebo`. The `ros-gz` package can be installed by setting the input parameter `install-ros-gz` to the required ROS 2 distributions.
+
+```yaml
+  jobs:
+    test_gazebo:
+      runs-on: ubuntu-latest
+      container:
+        image: ubuntu:jammy
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-node@v4.0.3
+          with:
+            node-version: '20.x'
+        - name: 'Install ROS 2 Iron and Rolling'
+          uses: ros-tooling/setup-ros@v0.7
+          with:
+            required-ros-distributions: 'rolling iron'
+        - name: 'Install Gazebo with ros_gz'
+          uses: gazebo-tooling/setup-gazebo@v0.1.0
+          with:
+            required-gazebo-distributions: 'harmonic'
+            install-ros-gz: 'rolling iron'
 ```
 
 ### macOS

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The `setup-gazebo` GitHub Action sets up an environment to install a Gazebo rele
 - `required-gazebo-distributions`: A **required** parameter that specifies the Gazebo distribution to be installed.
 - `use-gazebo-prerelease`: An **optional** parameter to install pre-release binaries from OSRF repository.
 - `use-gazebo-nightly`: An **optional** parameter to install nightly binaries from OSRF repository.
+- `install-ros-gz`: An **optional** parameter to install the ROS 2 Gazebo bridge (`ros_gz`).
 
 ## Supported platforms
 
@@ -46,6 +47,7 @@ The `setup-gazebo` action performs the following tasks:
   - Tapping into the [osrf/homebrew-simulation](https://github.com/osrf/homebrew-simulation) using Homebrew
 - On Windows:
   - Installing Gazebo using Conda from conda-forge
+
 ## Usage
 
 See [action.yml](action.yml)
@@ -253,7 +255,6 @@ This workflow shows how to install ROS 2 using the GitHub action `ros-tooling/se
 ```yaml
   jobs:
     test_gazebo:
-    name: 'Install Iron and Harmonic side-by-side'
     env:
       ROS_DISTROS: 'iron'
     runs-on: ubuntu-latest

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -173,3 +173,11 @@ describe("check for unstable repositories input", () => {
 		await expect(linux.runLinux()).resolves.not.toThrow();
 	});
 });
+
+describe("generate APT package names for ros_gz", () => {
+	it("test ROS 2 and gazebo combination", async () => {
+		await expect(
+			utils.generateRosAptPackageNames(["rolling", "iron"], ["harmonic"]),
+		).toEqual(["ros-rolling-ros-gz", "ros-iron-ros-gzharmonic"]);
+	});
+});

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -106,9 +106,7 @@ describe("validate ROS 2 distribution test", () => {
 	it("test valid distro", async () => {
 		await expect(utils.validateRosDistro(["humble"])).toBe(true);
 		await expect(utils.validateRosDistro(["iron"])).toBe(true);
-		await expect(utils.validateRosDistro(["jazzy"])).toBe(true);
-		await expect(utils.validateRosDistro(["rolling"])).toBe(true);
-		await expect(utils.validateRosDistro(["humble", "jazzy"])).toBe(true);
+		await expect(utils.validateRosDistro(["humble", "iron"])).toBe(true);
 	});
 	it("test invalid distro", async () => {
 		await expect(utils.validateRosDistro(["noetic"])).toBe(false);
@@ -179,11 +177,11 @@ describe("check for unstable repositories input", () => {
 describe("generate APT package names for ros_gz", () => {
 	it("test ros_gz output package names list", async () => {
 		await expect(
-			utils.generateRosAptPackageNames(["rolling", "iron"], ["harmonic"]),
-		).toEqual(["ros-rolling-ros-gz", "ros-iron-ros-gzharmonic"]);
+			utils.generateRosAptPackageNames(["humble", "iron"], ["harmonic"]),
+		).toEqual(["ros-humble-ros-gzharmonic", "ros-iron-ros-gzharmonic"]);
 		await expect(
-			utils.generateRosAptPackageNames(["jazzy"], ["harmonic"]),
-		).toEqual(["ros-jazzy-ros-gz"]);
+			utils.generateRosAptPackageNames(["humble"], ["fortress"]),
+		).toEqual(["ros-humble-ros-gz"]);
 		await expect(
 			utils.generateRosAptPackageNames(["iron"], ["fortress", "garden"]),
 		).toEqual(["ros-iron-ros-gz", "ros-iron-ros-gzgarden"]);

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -175,9 +175,15 @@ describe("check for unstable repositories input", () => {
 });
 
 describe("generate APT package names for ros_gz", () => {
-	it("test ROS 2 and gazebo combination", async () => {
+	it("test ros_gz output package names list", async () => {
 		await expect(
 			utils.generateRosAptPackageNames(["rolling", "iron"], ["harmonic"]),
 		).toEqual(["ros-rolling-ros-gz", "ros-iron-ros-gzharmonic"]);
+		await expect(
+			utils.generateRosAptPackageNames(["jazzy"], ["harmonic"]),
+		).toEqual(["ros-jazzy-ros-gz"]);
+		await expect(
+			utils.generateRosAptPackageNames(["iron"], ["fortress", "garden"]),
+		).toEqual(["ros-iron-ros-gz", "ros-iron-ros-gzgarden"]);
 	});
 });

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -32,6 +32,7 @@ describe("workflow test with a invalid distro input", () => {
 	beforeAll(() => {
 		jest.spyOn(exec, "exec").mockImplementation(jest.fn());
 		jest.spyOn(core, "getInput").mockReturnValue("dome");
+		jest.spyOn(utils, "checkForRosGz").mockReturnValue([]);
 	});
 
 	afterAll(() => {
@@ -55,6 +56,7 @@ describe("workflow test with a valid distro input", () => {
 	beforeAll(() => {
 		jest.spyOn(exec, "exec").mockImplementation(jest.fn());
 		jest.spyOn(core, "getInput").mockReturnValue("harmonic");
+		jest.spyOn(utils, "checkForRosGz").mockReturnValue([]);
 		jest
 			.spyOn(utils, "determineDistribCodename")
 			.mockReturnValue(Promise.resolve("jammy"));
@@ -77,7 +79,7 @@ describe("workflow test with a valid distro input", () => {
 	});
 });
 
-describe("validate distribution test", () => {
+describe("validate Gazebo distribution test", () => {
 	it("test valid distro", async () => {
 		await expect(utils.validateDistro(["citadel"])).toBe(true);
 		await expect(utils.validateDistro(["fortress"])).toBe(true);
@@ -98,10 +100,31 @@ describe("validate distribution test", () => {
 	});
 });
 
+describe("validate ROS 2 distribution test", () => {
+	it("test valid distro", async () => {
+		await expect(utils.validateRosDistro(["humble"])).toBe(true);
+		await expect(utils.validateRosDistro(["iron"])).toBe(true);
+		await expect(utils.validateRosDistro(["jazzy"])).toBe(true);
+		await expect(utils.validateRosDistro(["rolling"])).toBe(true);
+		await expect(utils.validateRosDistro(["humble", "jazzy"])).toBe(true);
+	});
+	it("test invalid distro", async () => {
+		await expect(utils.validateRosDistro(["noetic"])).toBe(false);
+		await expect(utils.validateRosDistro(["foxy"])).toBe(false);
+		await expect(utils.validateRosDistro(["galactic"])).toBe(false);
+		await expect(utils.validateRosDistro(["doesNotExist"])).toBe(false);
+		await expect(utils.validateRosDistro(["noetic", "humble"])).toBe(false);
+		await expect(utils.validateRosDistro(["foxy", "galactic", "jazzy"])).toBe(
+			false,
+		);
+	});
+});
+
 describe("workflow test with incompatible Ubuntu combination", () => {
 	beforeAll(() => {
 		jest.spyOn(exec, "exec").mockImplementation(jest.fn());
 		jest.spyOn(core, "getInput").mockReturnValue("harmonic");
+		jest.spyOn(utils, "checkForRosGz").mockReturnValue([]);
 		jest
 			.spyOn(utils, "determineDistribCodename")
 			.mockReturnValue(Promise.resolve("focal"));
@@ -128,6 +151,7 @@ describe("check for unstable repositories input", () => {
 			.spyOn(utils, "checkForUnstableAptRepos")
 			.mockReturnValueOnce(["prerelease", "nightly"]);
 		jest.spyOn(core, "getInput").mockReturnValue("harmonic");
+		jest.spyOn(utils, "checkForRosGz").mockReturnValue([]);
 		jest
 			.spyOn(utils, "determineDistribCodename")
 			.mockReturnValue(Promise.resolve("jammy"));

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -32,7 +32,7 @@ describe("workflow test with a invalid distro input", () => {
 	beforeAll(() => {
 		jest.spyOn(exec, "exec").mockImplementation(jest.fn());
 		jest.spyOn(core, "getInput").mockReturnValue("dome");
-		jest.spyOn(utils, "checkForRosGz").mockReturnValue([]);
+		jest.spyOn(utils, "checkForROSGz").mockReturnValue([]);
 	});
 
 	afterAll(() => {
@@ -56,7 +56,7 @@ describe("workflow test with a valid distro input", () => {
 	beforeAll(() => {
 		jest.spyOn(exec, "exec").mockImplementation(jest.fn());
 		jest.spyOn(core, "getInput").mockReturnValue("harmonic");
-		jest.spyOn(utils, "checkForRosGz").mockReturnValue([]);
+		jest.spyOn(utils, "checkForROSGz").mockReturnValue([]);
 		jest
 			.spyOn(utils, "determineDistribCodename")
 			.mockReturnValue(Promise.resolve("jammy"));
@@ -104,17 +104,17 @@ describe("validate Gazebo distribution test", () => {
 
 describe("validate ROS 2 distribution test", () => {
 	it("test valid distro", async () => {
-		await expect(utils.validateRosDistro(["humble"])).toBe(true);
-		await expect(utils.validateRosDistro(["iron"])).toBe(true);
-		await expect(utils.validateRosDistro(["humble", "iron"])).toBe(true);
+		await expect(utils.validateROSDistro(["humble"])).toBe(true);
+		await expect(utils.validateROSDistro(["iron"])).toBe(true);
+		await expect(utils.validateROSDistro(["humble", "iron"])).toBe(true);
 	});
 	it("test invalid distro", async () => {
-		await expect(utils.validateRosDistro(["noetic"])).toBe(false);
-		await expect(utils.validateRosDistro(["foxy"])).toBe(false);
-		await expect(utils.validateRosDistro(["galactic"])).toBe(false);
-		await expect(utils.validateRosDistro(["doesNotExist"])).toBe(false);
-		await expect(utils.validateRosDistro(["noetic", "humble"])).toBe(false);
-		await expect(utils.validateRosDistro(["foxy", "galactic", "jazzy"])).toBe(
+		await expect(utils.validateROSDistro(["noetic"])).toBe(false);
+		await expect(utils.validateROSDistro(["foxy"])).toBe(false);
+		await expect(utils.validateROSDistro(["galactic"])).toBe(false);
+		await expect(utils.validateROSDistro(["doesNotExist"])).toBe(false);
+		await expect(utils.validateROSDistro(["noetic", "humble"])).toBe(false);
+		await expect(utils.validateROSDistro(["foxy", "galactic", "jazzy"])).toBe(
 			false,
 		);
 	});
@@ -124,7 +124,7 @@ describe("workflow test with incompatible Ubuntu combination", () => {
 	beforeAll(() => {
 		jest.spyOn(exec, "exec").mockImplementation(jest.fn());
 		jest.spyOn(core, "getInput").mockReturnValue("harmonic");
-		jest.spyOn(utils, "checkForRosGz").mockReturnValue([]);
+		jest.spyOn(utils, "checkForROSGz").mockReturnValue([]);
 		jest
 			.spyOn(utils, "determineDistribCodename")
 			.mockReturnValue(Promise.resolve("focal"));
@@ -151,7 +151,7 @@ describe("check for unstable repositories input", () => {
 			.spyOn(utils, "checkForUnstableAptRepos")
 			.mockReturnValueOnce(["prerelease", "nightly"]);
 		jest.spyOn(core, "getInput").mockReturnValue("harmonic");
-		jest.spyOn(utils, "checkForRosGz").mockReturnValue([]);
+		jest.spyOn(utils, "checkForROSGz").mockReturnValue([]);
 		jest
 			.spyOn(utils, "determineDistribCodename")
 			.mockReturnValue(Promise.resolve("jammy"));
@@ -177,13 +177,13 @@ describe("check for unstable repositories input", () => {
 describe("generate APT package names for ros_gz", () => {
 	it("test ros_gz output package names list", async () => {
 		await expect(
-			utils.generateRosAptPackageNames(["humble", "iron"], ["harmonic"]),
+			utils.generateROSAptPackageNames(["humble", "iron"], ["harmonic"]),
 		).toEqual(["ros-humble-ros-gzharmonic", "ros-iron-ros-gzharmonic"]);
 		await expect(
-			utils.generateRosAptPackageNames(["humble"], ["fortress"]),
+			utils.generateROSAptPackageNames(["humble"], ["fortress"]),
 		).toEqual(["ros-humble-ros-gz"]);
 		await expect(
-			utils.generateRosAptPackageNames(["iron"], ["fortress", "garden"]),
+			utils.generateROSAptPackageNames(["iron"], ["fortress", "garden"]),
 		).toEqual(["ros-iron-ros-gz", "ros-iron-ros-gzgarden"]);
 	});
 });

--- a/action.yml
+++ b/action.yml
@@ -31,13 +31,11 @@ inputs:
     default: 'false'
   install-ros-gz:
     description: |
-      Install ros_gz side-by-side with ROS 2 and Gazebo
+      Install the ROS 2 Gazebo bridge (ros_gz)
 
       Allowed ROS 2 distributions
       - humble
       - iron
-      - jazzy
-      - rolling
 
       Multiple values can be passed using a whitespace delimited list
       "humble iron".

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,11 @@ inputs:
       Use nightly binaries from OSRF repository
     required: false
     default: 'false'
+  install-ros-gz:
+    description: |
+      Install ros_gz side-by-side with ROS 2 and Gazebo
+    required: false
+    default: 'false'
 runs:
   using: node20
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,17 @@ inputs:
   install-ros-gz:
     description: |
       Install ros_gz side-by-side with ROS 2 and Gazebo
+
+      Allowed ROS 2 distributions
+      - humble
+      - iron
+      - jazzy
+      - rolling
+
+      Multiple values can be passed using a whitespace delimited list
+      "humble iron".
     required: false
-    default: 'false'
+    default: ''
 runs:
   using: node20
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -26810,7 +26810,9 @@ const validGazeboDistroList = [
     "harmonic",
     "ionic",
 ];
-// List of valid ROS 2 distributions
+// List of valid ROS 2 distributions and compatible Gazebo mapping
+// For more information check the following link
+// https://gazebosim.org/docs/latest/ros_installation/#summary-of-compatible-ros-and-gazebo-combinations
 const validRosGzDistrosList = [
     {
         rosDistro: "humble",
@@ -26990,7 +26992,6 @@ function checkForUnstableAptRepos() {
 function checkForRosGz() {
     let requiredRosDistroList = [];
     const installRosGz = core.getInput("install-ros-gz");
-    console.log(installRosGz);
     if (installRosGz) {
         requiredRosDistroList = installRosGz.split(RegExp("\\s"));
         if (!validateRosDistro(requiredRosDistroList)) {
@@ -26999,6 +27000,13 @@ function checkForRosGz() {
     }
     return requiredRosDistroList;
 }
+/**
+ * Generate APT package name from ROS 2 and Gazebo distribution names
+ *
+ * @param rosGzDistrosList ROS 2 distro ros_gz packages to be installed
+ * @param requiredGazeboDistributionsList Installed Gazebo distributions
+ * @returns string [] List of APT package names
+ */
 function generateRosAptPackageNames(rosGzDistrosList, requiredGazeboDistributionsList) {
     const rosAptPackageNames = [];
     for (const rosDistro of rosGzDistrosList) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -26819,16 +26819,6 @@ const validRosGzDistrosList = [
         compatibleGazeboDistros: ["fortress"],
         useWithCautionGazeboDistros: ["garden", "harmonic"],
     },
-    {
-        rosDistro: "jazzy",
-        compatibleGazeboDistros: ["harmonic"],
-        useWithCautionGazeboDistros: ["garden"],
-    },
-    {
-        rosDistro: "rolling",
-        compatibleGazeboDistros: ["harmonic"],
-        useWithCautionGazeboDistros: ["garden"],
-    },
 ];
 /**
  * Execute a command and wrap the output in a log group.

--- a/dist/index.js
+++ b/dist/index.js
@@ -26387,6 +26387,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.runLinux = runLinux;
 const core = __importStar(__nccwpck_require__(2186));
 const io = __importStar(__nccwpck_require__(7436));
+const actions_exec = __importStar(__nccwpck_require__(1514));
 const apt = __importStar(__nccwpck_require__(4671));
 const utils = __importStar(__nccwpck_require__(1314));
 /**
@@ -26477,6 +26478,16 @@ function addAptRepo(ubuntuCodename) {
         yield utils.exec("sudo", ["apt-get", "update"]);
     });
 }
+function installRosGz() {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield utils.exec("bash", ["-c", `distros=($(ls /opt/ros -1))`]);
+        const output = yield actions_exec.getExecOutput("bash", [
+            "-c",
+            `echo $distros`,
+        ]);
+        console.log(output.stdout);
+    });
+}
 /**
  * Install Gazebo on a Linux worker.
  */
@@ -26492,6 +26503,7 @@ function runLinux() {
         for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
             yield apt.runAptGetInstall([`gz-${gazeboDistro}`]);
         }
+        yield installRosGz();
     });
 }
 
@@ -26790,6 +26802,7 @@ exports.validateDistro = validateDistro;
 exports.getRequiredGazeboDistributions = getRequiredGazeboDistributions;
 exports.checkUbuntuCompatibility = checkUbuntuCompatibility;
 exports.checkForUnstableAptRepos = checkForUnstableAptRepos;
+exports.checkForRosGz = checkForRosGz;
 const actions_exec = __importStar(__nccwpck_require__(1514));
 const core = __importStar(__nccwpck_require__(2186));
 // List of Valid Gazebo distributions with compatible
@@ -26798,22 +26811,27 @@ const validGazeboDistroList = [
     {
         name: "citadel",
         compatibleUbuntuDistros: ["focal"],
+        compatibleRosDistros: ["foxy"],
     },
     {
         name: "fortress",
         compatibleUbuntuDistros: ["focal", "jammy"],
+        compatibleRosDistros: ["humble", "iron"],
     },
     {
         name: "garden",
         compatibleUbuntuDistros: ["focal", "jammy"],
+        compatibleRosDistros: [],
     },
     {
         name: "harmonic",
         compatibleUbuntuDistros: ["jammy", "noble"],
+        compatibleRosDistros: ["jazzy", "rolling"],
     },
     {
         name: "ionic",
         compatibleUbuntuDistros: ["noble"],
+        compatibleRosDistros: [],
     },
 ];
 /**
@@ -26924,6 +26942,10 @@ function checkForUnstableAptRepos() {
         unstableRepos.push("nightly");
     }
     return unstableRepos;
+}
+function checkForRosGz() {
+    const installRosGz = core.getInput("install-ros-gz") === "true";
+    return installRosGz;
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -26492,9 +26492,9 @@ function runLinux() {
         for (const gazeboDistro of gazeboDistros) {
             yield apt.runAptGetInstall([`gz-${gazeboDistro}`]);
         }
-        const rosGzDistros = utils.checkForRosGz();
+        const rosGzDistros = utils.checkForROSGz();
         if (rosGzDistros.length > 0) {
-            const rosAptPackageNames = utils.generateRosAptPackageNames(rosGzDistros, gazeboDistros);
+            const rosAptPackageNames = utils.generateROSAptPackageNames(rosGzDistros, gazeboDistros);
             yield apt.runAptGetInstall(rosAptPackageNames);
         }
     });
@@ -26794,12 +26794,12 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.exec = exec;
 exports.determineDistribCodename = determineDistribCodename;
 exports.validateDistro = validateDistro;
-exports.validateRosDistro = validateRosDistro;
+exports.validateROSDistro = validateROSDistro;
 exports.getRequiredGazeboDistributions = getRequiredGazeboDistributions;
 exports.checkUbuntuCompatibility = checkUbuntuCompatibility;
 exports.checkForUnstableAptRepos = checkForUnstableAptRepos;
-exports.checkForRosGz = checkForRosGz;
-exports.generateRosAptPackageNames = generateRosAptPackageNames;
+exports.checkForROSGz = checkForROSGz;
+exports.generateROSAptPackageNames = generateROSAptPackageNames;
 const actions_exec = __importStar(__nccwpck_require__(1514));
 const core = __importStar(__nccwpck_require__(2186));
 const yaml_1 = __nccwpck_require__(4083);
@@ -26808,16 +26808,16 @@ const collections_url = "https://raw.githubusercontent.com/gazebo-tooling/releas
 // List of valid ROS 2 distributions and compatible Gazebo mapping
 // For more information check the following link
 // https://gazebosim.org/docs/latest/ros_installation/#summary-of-compatible-ros-and-gazebo-combinations
-const validRosGzDistrosList = [
+const validROSGzDistrosList = [
     {
         rosDistro: "humble",
-        compatibleGazeboDistros: ["fortress"],
-        useWithCautionGazeboDistros: ["garden", "harmonic"],
+        officialROSGzWrappers: ["fortress"],
+        unofficialROSGzWrappers: ["garden", "harmonic"],
     },
     {
         rosDistro: "iron",
-        compatibleGazeboDistros: ["fortress"],
-        useWithCautionGazeboDistros: ["garden", "harmonic"],
+        officialROSGzWrappers: ["fortress"],
+        unofficialROSGzWrappers: ["garden", "harmonic"],
     },
 ];
 /**
@@ -26887,9 +26887,9 @@ function validateDistro(requiredGazeboDistributionsList) {
  * @param rosGzDistrosList
  * @returns boolean Validaity of the ROS distribution
  */
-function validateRosDistro(rosGzDistrosList) {
+function validateROSDistro(rosGzDistrosList) {
     if (rosGzDistrosList.length > 0) {
-        const validDistro = validRosGzDistrosList.map((obj) => obj.rosDistro);
+        const validDistro = validROSGzDistrosList.map((obj) => obj.rosDistro);
         for (const rosDistro of rosGzDistrosList) {
             if (validDistro.indexOf(rosDistro) <= -1) {
                 return false;
@@ -26980,18 +26980,18 @@ function checkForUnstableAptRepos() {
 /**
  * Check for inputs to install ros-gz
  *
- * @returns requiredRosDistroList list of valid ROS 2 distributions
+ * @returns requiredROSDistroList list of valid ROS 2 distributions
  */
-function checkForRosGz() {
-    let requiredRosDistroList = [];
-    const installRosGz = core.getInput("install-ros-gz");
-    if (installRosGz) {
-        requiredRosDistroList = installRosGz.split(RegExp("\\s"));
-        if (!validateRosDistro(requiredRosDistroList)) {
+function checkForROSGz() {
+    let requiredROSDistroList = [];
+    const installROSGz = core.getInput("install-ros-gz");
+    if (installROSGz) {
+        requiredROSDistroList = installROSGz.split(RegExp("\\s"));
+        if (!validateROSDistro(requiredROSDistroList)) {
             throw new Error("Input has invalid ROS 2 distribution names.");
         }
     }
-    return requiredRosDistroList;
+    return requiredROSDistroList;
 }
 /**
  * Generate APT package name from ROS 2 and Gazebo distribution names
@@ -27000,15 +27000,15 @@ function checkForRosGz() {
  * @param requiredGazeboDistributionsList Installed Gazebo distributions
  * @returns string [] List of APT package names
  */
-function generateRosAptPackageNames(rosGzDistrosList, requiredGazeboDistributionsList) {
+function generateROSAptPackageNames(rosGzDistrosList, requiredGazeboDistributionsList) {
     const rosAptPackageNames = [];
     for (const rosDistro of rosGzDistrosList) {
-        const distroInfo = validRosGzDistrosList.find((distro) => distro.rosDistro === rosDistro);
+        const distroInfo = validROSGzDistrosList.find((distro) => distro.rosDistro === rosDistro);
         for (const gazeboDistro of requiredGazeboDistributionsList) {
-            if (distroInfo.compatibleGazeboDistros.indexOf(gazeboDistro) > -1) {
+            if (distroInfo.officialROSGzWrappers.indexOf(gazeboDistro) > -1) {
                 rosAptPackageNames.push(`ros-${rosDistro}-ros-gz`);
             }
-            else if (distroInfo.useWithCautionGazeboDistros.indexOf(gazeboDistro) > -1) {
+            else if (distroInfo.unofficialROSGzWrappers.indexOf(gazeboDistro) > -1) {
                 rosAptPackageNames.push(`ros-${rosDistro}-ros-gz${gazeboDistro}`);
             }
             else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -26479,15 +26479,18 @@ function addAptRepo(ubuntuCodename) {
 }
 function installRosGz() {
     return __awaiter(this, void 0, void 0, function* () {
-        let rosDistros = "";
+        let rosDistroStr = "";
         const options = {};
         options.listeners = {
             stdout: (data) => {
-                rosDistros += data.toString();
+                rosDistroStr += data.toString();
             },
         };
         yield utils.exec("bash", ["-c", `distros=($(ls /opt/ros -1)) ; echo -n "$distros"`], options);
-        return rosDistros;
+        const rosDistros = rosDistroStr.split(" ");
+        for (const rosDistro of rosDistros) {
+            apt.runAptGetInstall([`ros-${rosDistro}-ros-gz`]);
+        }
     });
 }
 /**
@@ -26505,8 +26508,9 @@ function runLinux() {
         for (const gazeboDistro of gazeboDistros) {
             yield apt.runAptGetInstall([`gz-${gazeboDistro}`]);
         }
-        const rosDistros = yield installRosGz();
-        console.log(rosDistros);
+        if (utils.checkForRosGz()) {
+            yield installRosGz();
+        }
     });
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -26486,10 +26486,7 @@ function installRosGz() {
                 rosDistros += data.toString();
             },
         };
-        yield utils.exec("bash", [
-            "-c",
-            `distros=($(ls /opt/ros -1)) ; echo -n "$distros"`,
-        ]);
+        yield utils.exec("bash", ["-c", `distros=($(ls /opt/ros -1)) ; echo -n "$distros"`], options);
         return rosDistros;
     });
 }
@@ -26505,7 +26502,7 @@ function runLinux() {
         yield addAptRepo(ubuntuCodename);
         const gazeboDistros = utils.getRequiredGazeboDistributions();
         utils.checkUbuntuCompatibility(gazeboDistros, ubuntuCodename);
-        for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
+        for (const gazeboDistro of gazeboDistros) {
             yield apt.runAptGetInstall([`gz-${gazeboDistro}`]);
         }
         const rosDistros = yield installRosGz();

--- a/dist/index.js
+++ b/dist/index.js
@@ -27008,7 +27008,7 @@ function generateRosAptPackageNames(rosGzDistrosList, requiredGazeboDistribution
                 rosAptPackageNames.push(`ros-${rosDistro}-ros-gz`);
             }
             else if (distroInfo.useWithCautionGazeboDistros.indexOf(gazeboDistro) > -1) {
-                rosAptPackageNames.push(`ros-${rosDistro}-ros_gz${gazeboDistro}`);
+                rosAptPackageNames.push(`ros-${rosDistro}-ros-gz${gazeboDistro}`);
             }
             else {
                 throw new Error("Impossible ROS 2 and Gazebo combination requested. \

--- a/dist/index.js
+++ b/dist/index.js
@@ -26387,7 +26387,6 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.runLinux = runLinux;
 const core = __importStar(__nccwpck_require__(2186));
 const io = __importStar(__nccwpck_require__(7436));
-const actions_exec = __importStar(__nccwpck_require__(1514));
 const apt = __importStar(__nccwpck_require__(4671));
 const utils = __importStar(__nccwpck_require__(1314));
 /**
@@ -26480,12 +26479,18 @@ function addAptRepo(ubuntuCodename) {
 }
 function installRosGz() {
     return __awaiter(this, void 0, void 0, function* () {
-        yield utils.exec("bash", ["-c", `distros=($(ls /opt/ros -1))`]);
-        const output = yield actions_exec.getExecOutput("bash", [
+        let rosDistros = "";
+        const options = {};
+        options.listeners = {
+            stdout: (data) => {
+                rosDistros += data.toString();
+            },
+        };
+        yield utils.exec("bash", [
             "-c",
-            `echo $distros`,
+            `distros=($(ls /opt/ros -1)) ; echo -n "$distros"`,
         ]);
-        console.log(output.stdout);
+        return rosDistros;
     });
 }
 /**
@@ -26503,7 +26508,8 @@ function runLinux() {
         for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
             yield apt.runAptGetInstall([`gz-${gazeboDistro}`]);
         }
-        yield installRosGz();
+        const rosDistros = yield installRosGz();
+        console.log(rosDistros);
     });
 }
 

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -94,26 +94,6 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
 	await utils.exec("sudo", ["apt-get", "update"]);
 }
 
-async function installRosGz(): Promise<void> {
-	let rosDistroStr: string = "";
-	const options: im.ExecOptions = {};
-	options.listeners = {
-		stdout: (data: Buffer) => {
-			rosDistroStr += data.toString();
-		},
-	};
-	await utils.exec(
-		"bash",
-		["-c", `distros=($(ls /opt/ros -1)) ; echo -n "$distros"`],
-		options,
-	);
-
-	const rosDistros: string[] = rosDistroStr.split(" ");
-	for (const rosDistro of rosDistros) {
-		apt.runAptGetInstall([`ros-${rosDistro}-ros-gz`]);
-	}
-}
-
 /**
  * Install Gazebo on a Linux worker.
  */
@@ -133,7 +113,8 @@ export async function runLinux(): Promise<void> {
 		await apt.runAptGetInstall([`gz-${gazeboDistro}`]);
 	}
 
-	if (utils.checkForRosGz()) {
-		await installRosGz();
+	const rosGzDistros = utils.checkForRosGz();
+	for (const rosGzDistro of rosGzDistros) {
+		await apt.runAptGetInstall([`ros-${rosGzDistro}-ros-gz`]);
 	}
 }

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -1,5 +1,6 @@
 import * as core from "@actions/core";
 import * as io from "@actions/io";
+import * as actions_exec from "@actions/exec";
 
 import * as apt from "./package_manager/apt";
 import * as utils from "./utils";
@@ -92,6 +93,15 @@ async function addAptRepo(ubuntuCodename: string): Promise<void> {
 	await utils.exec("sudo", ["apt-get", "update"]);
 }
 
+async function installRosGz(): Promise<void> {
+	await utils.exec("bash", ["-c", `distros=($(ls /opt/ros -1))`]);
+	const output = await actions_exec.getExecOutput("bash", [
+		"-c",
+		`echo $distros`,
+	]);
+	console.log(output.stdout);
+}
+
 /**
  * Install Gazebo on a Linux worker.
  */
@@ -110,4 +120,5 @@ export async function runLinux(): Promise<void> {
 	for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
 		await apt.runAptGetInstall([`gz-${gazeboDistro}`]);
 	}
+	await installRosGz();
 }

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -102,10 +102,11 @@ async function installRosGz(): Promise<string> {
 			rosDistros += data.toString();
 		},
 	};
-	await utils.exec("bash", [
-		"-c",
-		`distros=($(ls /opt/ros -1)) ; echo -n "$distros"`,
-	]);
+	await utils.exec(
+		"bash",
+		["-c", `distros=($(ls /opt/ros -1)) ; echo -n "$distros"`],
+		options,
+	);
 	return rosDistros;
 }
 
@@ -124,7 +125,7 @@ export async function runLinux(): Promise<void> {
 
 	utils.checkUbuntuCompatibility(gazeboDistros, ubuntuCodename);
 
-	for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
+	for (const gazeboDistro of gazeboDistros) {
 		await apt.runAptGetInstall([`gz-${gazeboDistro}`]);
 	}
 	const rosDistros = await installRosGz();

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -113,9 +113,9 @@ export async function runLinux(): Promise<void> {
 		await apt.runAptGetInstall([`gz-${gazeboDistro}`]);
 	}
 
-	const rosGzDistros = utils.checkForRosGz();
+	const rosGzDistros = utils.checkForROSGz();
 	if (rosGzDistros.length > 0) {
-		const rosAptPackageNames = utils.generateRosAptPackageNames(
+		const rosAptPackageNames = utils.generateROSAptPackageNames(
 			rosGzDistros,
 			gazeboDistros,
 		);

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -114,7 +114,11 @@ export async function runLinux(): Promise<void> {
 	}
 
 	const rosGzDistros = utils.checkForRosGz();
-	for (const rosGzDistro of rosGzDistros) {
-		await apt.runAptGetInstall([`ros-${rosGzDistro}-ros-gz`]);
+	if (rosGzDistros.length > 0) {
+		const rosAptPackageNames = utils.generateRosAptPackageNames(
+			rosGzDistros,
+			gazeboDistros,
+		);
+		await apt.runAptGetInstall(rosAptPackageNames);
 	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,16 +25,6 @@ const validRosGzDistrosList: {
 		compatibleGazeboDistros: ["fortress"],
 		useWithCautionGazeboDistros: ["garden", "harmonic"],
 	},
-	{
-		rosDistro: "jazzy",
-		compatibleGazeboDistros: ["harmonic"],
-		useWithCautionGazeboDistros: ["garden"],
-	},
-	{
-		rosDistro: "rolling",
-		compatibleGazeboDistros: ["harmonic"],
-		useWithCautionGazeboDistros: ["garden"],
-	},
 ];
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,9 @@ const validGazeboDistroList: {
 	},
 ];
 
+// List of valid ROS 2 distributions
+const validRosGzDistrosList: string[] = ["humble", "iron", "jazzy", "rolling"];
+
 /**
  * Execute a command and wrap the output in a log group.
  *
@@ -94,6 +97,23 @@ export function validateDistro(
 	const validDistro: string[] = validGazeboDistroList.map((obj) => obj.name);
 	for (const gazeboDistro of requiredGazeboDistributionsList) {
 		if (validDistro.indexOf(gazeboDistro) <= -1) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Validate all ROS distribution names
+ *
+ * @returns boolean Validaity of the ROS distribution
+ */
+export function validateRosDistro(rosGzDistrosList: string[]): boolean {
+	if (rosGzDistrosList.length <= 0) {
+		return true;
+	}
+	for (const rosDistro of rosGzDistrosList) {
+		if (validRosGzDistrosList.indexOf(rosDistro) <= -1) {
 			return false;
 		}
 	}
@@ -168,7 +188,19 @@ export function checkForUnstableAptRepos(): string[] {
 	return unstableRepos;
 }
 
-export function checkForRosGz(): boolean {
-	const installRosGz = core.getInput("install-ros-gz") === "true";
-	return installRosGz;
+/**
+ * Check for inputs to install ros-gz
+ *
+ * @returns requiredRosDistroList list of valid ROS 2 distributions
+ */
+export function checkForRosGz(): string[] {
+	let requiredRosDistroList: string[] = [];
+	const installRosGz = core.getInput("install-ros-gz");
+	if (installRosGz) {
+		requiredRosDistroList = installRosGz.split(RegExp("\\s"));
+	}
+	if (!validateRosDistro(requiredRosDistroList)) {
+		throw new Error("Input has invalid ROS 2 distribution names.");
+	}
+	return requiredRosDistroList;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -252,7 +252,7 @@ export function generateRosAptPackageNames(
 			} else if (
 				distroInfo!.useWithCautionGazeboDistros.indexOf(gazeboDistro) > -1
 			) {
-				rosAptPackageNames.push(`ros-${rosDistro}-ros_gz${gazeboDistro}`);
+				rosAptPackageNames.push(`ros-${rosDistro}-ros-gz${gazeboDistro}`);
 			} else {
 				throw new Error(
 					"Impossible ROS 2 and Gazebo combination requested. \

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,9 @@ const validGazeboDistroList: string[] = [
 	"ionic",
 ];
 
-// List of valid ROS 2 distributions
+// List of valid ROS 2 distributions and compatible Gazebo mapping
+// For more information check the following link
+// https://gazebosim.org/docs/latest/ros_installation/#summary-of-compatible-ros-and-gazebo-combinations
 const validRosGzDistrosList: {
 	rosDistro: string;
 	compatibleGazeboDistros: string[];
@@ -227,7 +229,6 @@ export function checkForUnstableAptRepos(): string[] {
 export function checkForRosGz(): string[] {
 	let requiredRosDistroList: string[] = [];
 	const installRosGz = core.getInput("install-ros-gz");
-	console.log(installRosGz);
 	if (installRosGz) {
 		requiredRosDistroList = installRosGz.split(RegExp("\\s"));
 		if (!validateRosDistro(requiredRosDistroList)) {
@@ -237,6 +238,13 @@ export function checkForRosGz(): string[] {
 	return requiredRosDistroList;
 }
 
+/**
+ * Generate APT package name from ROS 2 and Gazebo distribution names
+ *
+ * @param rosGzDistrosList ROS 2 distro ros_gz packages to be installed
+ * @param requiredGazeboDistributionsList Installed Gazebo distributions
+ * @returns string [] List of APT package names
+ */
 export function generateRosAptPackageNames(
 	rosGzDistrosList: string[],
 	requiredGazeboDistributionsList: string[],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,26 +7,32 @@ import * as im from "@actions/exec/lib/interfaces";
 const validGazeboDistroList: {
 	name: string;
 	compatibleUbuntuDistros: string[];
+	compatibleRosDistros: string[];
 }[] = [
 	{
 		name: "citadel",
 		compatibleUbuntuDistros: ["focal"],
+		compatibleRosDistros: ["foxy"],
 	},
 	{
 		name: "fortress",
 		compatibleUbuntuDistros: ["focal", "jammy"],
+		compatibleRosDistros: ["humble", "iron"],
 	},
 	{
 		name: "garden",
 		compatibleUbuntuDistros: ["focal", "jammy"],
+		compatibleRosDistros: [],
 	},
 	{
 		name: "harmonic",
 		compatibleUbuntuDistros: ["jammy", "noble"],
+		compatibleRosDistros: ["jazzy", "rolling"],
 	},
 	{
 		name: "ionic",
 		compatibleUbuntuDistros: ["noble"],
+		compatibleRosDistros: [],
 	},
 ];
 
@@ -160,4 +166,9 @@ export function checkForUnstableAptRepos(): string[] {
 		unstableRepos.push("nightly");
 	}
 	return unstableRepos;
+}
+
+export function checkForRosGz(): boolean {
+	const installRosGz = core.getInput("install-ros-gz") === "true";
+	return installRosGz;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,20 +10,20 @@ const collections_url: string =
 // List of valid ROS 2 distributions and compatible Gazebo mapping
 // For more information check the following link
 // https://gazebosim.org/docs/latest/ros_installation/#summary-of-compatible-ros-and-gazebo-combinations
-const validRosGzDistrosList: {
+const validROSGzDistrosList: {
 	rosDistro: string;
-	compatibleGazeboDistros: string[];
-	useWithCautionGazeboDistros: string[];
+	officialROSGzWrappers: string[];
+	unofficialROSGzWrappers: string[];
 }[] = [
 	{
 		rosDistro: "humble",
-		compatibleGazeboDistros: ["fortress"],
-		useWithCautionGazeboDistros: ["garden", "harmonic"],
+		officialROSGzWrappers: ["fortress"],
+		unofficialROSGzWrappers: ["garden", "harmonic"],
 	},
 	{
 		rosDistro: "iron",
-		compatibleGazeboDistros: ["fortress"],
-		useWithCautionGazeboDistros: ["garden", "harmonic"],
+		officialROSGzWrappers: ["fortress"],
+		unofficialROSGzWrappers: ["garden", "harmonic"],
 	},
 ];
 
@@ -104,9 +104,9 @@ export async function validateDistro(
  * @param rosGzDistrosList
  * @returns boolean Validaity of the ROS distribution
  */
-export function validateRosDistro(rosGzDistrosList: string[]): boolean {
+export function validateROSDistro(rosGzDistrosList: string[]): boolean {
 	if (rosGzDistrosList.length > 0) {
-		const validDistro: string[] = validRosGzDistrosList.map(
+		const validDistro: string[] = validROSGzDistrosList.map(
 			(obj) => obj.rosDistro,
 		);
 		for (const rosDistro of rosGzDistrosList) {
@@ -214,18 +214,18 @@ export function checkForUnstableAptRepos(): string[] {
 /**
  * Check for inputs to install ros-gz
  *
- * @returns requiredRosDistroList list of valid ROS 2 distributions
+ * @returns requiredROSDistroList list of valid ROS 2 distributions
  */
-export function checkForRosGz(): string[] {
-	let requiredRosDistroList: string[] = [];
-	const installRosGz = core.getInput("install-ros-gz");
-	if (installRosGz) {
-		requiredRosDistroList = installRosGz.split(RegExp("\\s"));
-		if (!validateRosDistro(requiredRosDistroList)) {
+export function checkForROSGz(): string[] {
+	let requiredROSDistroList: string[] = [];
+	const installROSGz = core.getInput("install-ros-gz");
+	if (installROSGz) {
+		requiredROSDistroList = installROSGz.split(RegExp("\\s"));
+		if (!validateROSDistro(requiredROSDistroList)) {
 			throw new Error("Input has invalid ROS 2 distribution names.");
 		}
 	}
-	return requiredRosDistroList;
+	return requiredROSDistroList;
 }
 
 /**
@@ -235,20 +235,20 @@ export function checkForRosGz(): string[] {
  * @param requiredGazeboDistributionsList Installed Gazebo distributions
  * @returns string [] List of APT package names
  */
-export function generateRosAptPackageNames(
+export function generateROSAptPackageNames(
 	rosGzDistrosList: string[],
 	requiredGazeboDistributionsList: string[],
 ): string[] {
 	const rosAptPackageNames: string[] = [];
 	for (const rosDistro of rosGzDistrosList) {
-		const distroInfo = validRosGzDistrosList.find(
+		const distroInfo = validROSGzDistrosList.find(
 			(distro) => distro.rosDistro === rosDistro,
 		);
 		for (const gazeboDistro of requiredGazeboDistributionsList) {
-			if (distroInfo!.compatibleGazeboDistros.indexOf(gazeboDistro) > -1) {
+			if (distroInfo!.officialROSGzWrappers.indexOf(gazeboDistro) > -1) {
 				rosAptPackageNames.push(`ros-${rosDistro}-ros-gz`);
 			} else if (
-				distroInfo!.useWithCautionGazeboDistros.indexOf(gazeboDistro) > -1
+				distroInfo!.unofficialROSGzWrappers.indexOf(gazeboDistro) > -1
 			) {
 				rosAptPackageNames.push(`ros-${rosDistro}-ros-gz${gazeboDistro}`);
 			} else {


### PR DESCRIPTION
Closes #62 

## Summary
This PR installs `ros_gz` using input from the user. A mapping is present as a list containing the compatible ROS 2/Gazebo distributions and the ones with the "use with caution" warning.

## Implementation
- The ROS 2 distributions are validated and then the internal mapping is checked to see if the installed Gazebo distributions fall in the "compatible" or "use with caution" list. 
- If a Gazebo distribution is "compatible" then the following package name is generated - `ros-$ROS_DISTRO-ros-gz`.
- If a Gazebo distribution is to be "used with caution" then the following package name is generated - `ros-$ROS_DISTRO-ros-gz$GAZEBO_VERSION`
- Added a job in workflow to test the implementation

## Pending tasks
- [x] Perform check for ROS 2 and Gazebo compatibility
- [x] Write tests
- [x] Update documentation