### PR TITLE
Validating list Gazebo distributions using collections YAML

### DIFF
--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -79,22 +79,24 @@ describe("workflow test with a valid distro input", () => {
 
 describe("validate distribution test", () => {
 	it("test valid distro", async () => {
-		await expect(utils.validateDistro(["citadel"])).toBe(true);
-		await expect(utils.validateDistro(["fortress"])).toBe(true);
-		await expect(utils.validateDistro(["garden"])).toBe(true);
-		await expect(utils.validateDistro(["harmonic"])).toBe(true);
-		await expect(utils.validateDistro(["fortress", "garden"])).toBe(true);
+		await expect(utils.validateDistro(["citadel"])).resolves.not.toThrow();
+		await expect(utils.validateDistro(["fortress"])).resolves.not.toThrow();
+		await expect(utils.validateDistro(["garden"])).resolves.not.toThrow();
+		await expect(utils.validateDistro(["harmonic"])).resolves.not.toThrow();
+		await expect(
+			utils.validateDistro(["fortress", "garden"]),
+		).resolves.not.toThrow();
 	});
 	it("test invalid distro", async () => {
-		await expect(utils.validateDistro(["acropolis"])).toBe(false);
-		await expect(utils.validateDistro(["blueprint"])).toBe(false);
-		await expect(utils.validateDistro(["dome"])).toBe(false);
-		await expect(utils.validateDistro(["edifice"])).toBe(false);
-		await expect(utils.validateDistro(["doesNotExist"])).toBe(false);
-		await expect(utils.validateDistro(["dome", "fortress"])).toBe(false);
-		await expect(utils.validateDistro(["citadel", "edifice", "harmonic"])).toBe(
-			false,
-		);
+		await expect(utils.validateDistro(["acropolis"])).rejects.toThrow();
+		await expect(utils.validateDistro(["blueprint"])).rejects.toThrow();
+		await expect(utils.validateDistro(["dome"])).rejects.toThrow();
+		await expect(utils.validateDistro(["edifice"])).rejects.toThrow();
+		await expect(utils.validateDistro(["doesNotExist"])).rejects.toThrow();
+		await expect(utils.validateDistro(["dome", "fortress"])).rejects.toThrow();
+		await expect(
+			utils.validateDistro(["citadel", "edifice", "harmonic"]),
+		).rejects.toThrow();
 	});
 });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -26795,6 +26795,7 @@ exports.checkForUnstableAptRepos = checkForUnstableAptRepos;
 const actions_exec = __importStar(__nccwpck_require__(1514));
 const core = __importStar(__nccwpck_require__(2186));
 const yaml_1 = __nccwpck_require__(4083);
+// Collections file that contains all the valid Gazebo distributions along all compatiblity information
 const collections_url = "https://raw.githubusercontent.com/gazebo-tooling/release-tools/master/jenkins-scripts/dsl/gz-collections.yaml";
 /**
  * Execute a command and wrap the output in a log group.

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -103,11 +103,11 @@ export async function runLinux(): Promise<void> {
 	const ubuntuCodename = await utils.determineDistribCodename();
 	await addAptRepo(ubuntuCodename);
 
-	const gazeboDistros = utils.getRequiredGazeboDistributions();
+	const gazeboDistros = await utils.getRequiredGazeboDistributions();
 
 	await utils.checkUbuntuCompatibility(gazeboDistros, ubuntuCodename);
 
-	for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
+	for (const gazeboDistro of gazeboDistros) {
 		await apt.runAptGetInstall([`gz-${gazeboDistro}`]);
 	}
 }

--- a/src/setup-gazebo-macos.ts
+++ b/src/setup-gazebo-macos.ts
@@ -36,7 +36,9 @@ export async function runMacOs(): Promise<void> {
 
 	await overwritePythonInstall();
 
-	for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
+	const gazeboDistros = await utils.getRequiredGazeboDistributions();
+
+	for (const gazeboDistro of gazeboDistros) {
 		await brew.runBrew([`gz-${gazeboDistro}`]);
 	}
 }

--- a/src/setup-gazebo-windows.ts
+++ b/src/setup-gazebo-windows.ts
@@ -38,7 +38,9 @@ async function getLibVersion(gazeboDistro: string): Promise<number> {
  * Install Gazebo on a Windows worker
  */
 export async function runWindows(): Promise<void> {
-	for (const gazeboDistro of utils.getRequiredGazeboDistributions()) {
+	const gazeboDistros = await utils.getRequiredGazeboDistributions();
+
+	for (const gazeboDistro of gazeboDistros) {
 		const version = await getLibVersion(gazeboDistro);
 		await conda.runConda([`gz-sim${version}`]);
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import * as core from "@actions/core";
 import * as im from "@actions/exec/lib/interfaces";
 import { parseDocument } from "yaml";
 
+// Collections file that contains all the valid Gazebo distributions along all compatiblity information
 const collections_url: string =
 	"https://raw.githubusercontent.com/gazebo-tooling/release-tools/master/jenkins-scripts/dsl/gz-collections.yaml";
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,15 +3,8 @@ import * as core from "@actions/core";
 import * as im from "@actions/exec/lib/interfaces";
 import { parseDocument } from "yaml";
 
-// List of Valid Gazebo distributions with compatible
-// Ubuntu distributions
-const validGazeboDistroList: string[] = [
-	"citadel",
-	"fortress",
-	"garden",
-	"harmonic",
-	"ionic",
-];
+const collections_url: string =
+	"https://raw.githubusercontent.com/gazebo-tooling/release-tools/master/jenkins-scripts/dsl/gz-collections.yaml";
 
 /**
  * Execute a command and wrap the output in a log group.
@@ -63,26 +56,34 @@ export async function determineDistribCodename(): Promise<string> {
  * Validate all Gazebo input distribution names
  *
  * @param requiredGazeboDistributionsList
- * @returns boolean Validity of Gazebo distribution
+ * @returns Promise<void>
  */
-export function validateDistro(
+export async function validateDistro(
 	requiredGazeboDistributionsList: string[],
-): boolean {
-	for (const gazeboDistro of requiredGazeboDistributionsList) {
-		if (validGazeboDistroList.indexOf(gazeboDistro) <= -1) {
-			return false;
-		}
-	}
-	return true;
+): Promise<void> {
+	await fetch(collections_url)
+		.then((response) => response.blob())
+		.then((blob) => blob.text())
+		.then((yamlStr) => {
+			const collections = parseDocument(yamlStr).toJSON();
+			requiredGazeboDistributionsList.forEach((gazeboDistro) => {
+				const valid: boolean = collections["collections"].some(
+					(collectionsDistro: any) => collectionsDistro.name === gazeboDistro,
+				);
+				if (!valid) {
+					throw new Error("Input has invalid distribution names.");
+				}
+			});
+		});
 }
 
 /**
  * Gets the input of the Gazebo distributions to be installed and
  * validates them
  *
- * @returns string[] List of validated Gazebo distributions
+ * @returns Promise<string[]> List of validated Gazebo distributions
  */
-export function getRequiredGazeboDistributions(): string[] {
+export async function getRequiredGazeboDistributions(): Promise<string[]> {
 	let requiredGazeboDistributionsList: string[] = [];
 	const requiredGazeboDistributions = core.getInput(
 		"required-gazebo-distributions",
@@ -94,9 +95,9 @@ export function getRequiredGazeboDistributions(): string[] {
 	} else {
 		throw new Error("Input cannot be empty.");
 	}
-	if (!validateDistro(requiredGazeboDistributionsList)) {
-		throw new Error("Input has invalid distribution names.");
-	}
+
+	await validateDistro(requiredGazeboDistributionsList);
+
 	return requiredGazeboDistributionsList;
 }
 
@@ -113,9 +114,7 @@ export async function checkUbuntuCompatibility(
 	requiredGazeboDistributionsList: string[],
 	ubuntuCodename: string,
 ): Promise<void> {
-	await fetch(
-		"https://raw.githubusercontent.com/gazebo-tooling/release-tools/master/jenkins-scripts/dsl/gz-collections.yaml",
-	)
+	await fetch(collections_url)
 		.then((response) => response.blob())
 		.then((blob) => blob.text())
 		.then((yamlStr) => {


### PR DESCRIPTION
Closes #49

## Summary
Previously input Gazebo distributions were validated against a hardcoded list of distribution names. Now the validation is done by fetching the collections YAML.
