### PR TITLE
Added vendor installation support for Jazzy and Rolling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -310,3 +310,30 @@ jobs:
           source /opt/ros/humble/setup.bash
           ros2 pkg list | grep ros_gz
           ign gazebo --version | grep 'version 6.*'
+
+  test_install_ros_gz_vendor:
+    name: 'Install Harmonic on Jazzy through vendor packages'
+    env:
+      ROS_DISTROS: 'jazzy'
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:noble
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: '20.x'
+      - name: 'Install ROS 2 Jazzy'
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: ${{ env.ROS_DISTROS }}
+      - name: 'Install Gazebo with ros_gz'
+        uses: ./
+        with:
+          required-gazebo-distributions: 'harmonic'
+          install-ros-gz: ${{ env.ROS_DISTROS }}
+      - name: Test Jazzy ros_gz installation
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          ros2 pkg list | grep ros_gz
+          gz sim --version | grep 'version 8.[0-9*].[0-9*]'

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -106,6 +106,8 @@ describe("validate ROS 2 distribution test", () => {
 	it("test valid distro", async () => {
 		await expect(utils.validateROSDistro(["humble"])).toBe(true);
 		await expect(utils.validateROSDistro(["iron"])).toBe(true);
+		await expect(utils.validateROSDistro(["jazzy"])).toBe(true);
+		await expect(utils.validateROSDistro(["rolling"])).toBe(true);
 		await expect(utils.validateROSDistro(["humble", "iron"])).toBe(true);
 	});
 	it("test invalid distro", async () => {
@@ -185,5 +187,34 @@ describe("generate APT package names for ros_gz", () => {
 		await expect(
 			utils.generateROSAptPackageNames(["iron"], ["fortress", "garden"]),
 		).toEqual(["ros-iron-ros-gz", "ros-iron-ros-gzgarden"]);
+		await expect(
+			utils.generateROSAptPackageNames(["jazzy"], ["harmonic"]),
+		).toEqual(["ros-jazzy-ros-gz"]);
+		await expect(
+			utils.generateROSAptPackageNames(["rolling"], ["harmonic"]),
+		).toEqual(["ros-rolling-ros-gz"]);
+	});
+});
+
+describe("check for Gazebo vendor packages for ROS 2 distribution", () => {
+	it("test for Gazebo vendor packages", async () => {
+		await expect(
+			utils.checkForROSGzVendorPackages("garden", ["humble"]),
+		).toEqual(false);
+		await expect(
+			utils.checkForROSGzVendorPackages("harmonic", ["iron"]),
+		).toEqual(false);
+		await expect(
+			utils.checkForROSGzVendorPackages("harmonic", ["jazzy"]),
+		).toEqual(true);
+		await expect(
+			utils.checkForROSGzVendorPackages("harmonic", ["rolling"]),
+		).toEqual(true);
+		await expect(
+			utils.checkForROSGzVendorPackages("fortress", ["humble", "iron"]),
+		).toEqual(false);
+		await expect(
+			utils.checkForROSGzVendorPackages("harmonic", ["rolling", "jazzy"]),
+		).toEqual(true);
 	});
 });

--- a/src/setup-gazebo-linux.ts
+++ b/src/setup-gazebo-linux.ts
@@ -109,11 +109,14 @@ export async function runLinux(): Promise<void> {
 
 	await utils.checkUbuntuCompatibility(gazeboDistros, ubuntuCodename);
 
+	const rosGzDistros = utils.checkForROSGz();
+
 	for (const gazeboDistro of gazeboDistros) {
-		await apt.runAptGetInstall([`gz-${gazeboDistro}`]);
+		if (!utils.checkForROSGzVendorPackages(gazeboDistro, rosGzDistros)) {
+			await apt.runAptGetInstall([`gz-${gazeboDistro}`]);
+		}
 	}
 
-	const rosGzDistros = utils.checkForROSGz();
 	if (rosGzDistros.length > 0) {
 		const rosAptPackageNames = utils.generateROSAptPackageNames(
 			rosGzDistros,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,16 +14,31 @@ const validROSGzDistrosList: {
 	rosDistro: string;
 	officialROSGzWrappers: string[];
 	unofficialROSGzWrappers: string[];
+	vendorPackagesAvailable: boolean;
 }[] = [
 	{
 		rosDistro: "humble",
 		officialROSGzWrappers: ["fortress"],
 		unofficialROSGzWrappers: ["garden", "harmonic"],
+		vendorPackagesAvailable: false,
 	},
 	{
 		rosDistro: "iron",
 		officialROSGzWrappers: ["fortress"],
 		unofficialROSGzWrappers: ["garden", "harmonic"],
+		vendorPackagesAvailable: false,
+	},
+	{
+		rosDistro: "jazzy",
+		officialROSGzWrappers: ["harmonic"],
+		unofficialROSGzWrappers: [],
+		vendorPackagesAvailable: true,
+	},
+	{
+		rosDistro: "rolling",
+		officialROSGzWrappers: ["harmonic"],
+		unofficialROSGzWrappers: [],
+		vendorPackagesAvailable: true,
 	},
 ];
 
@@ -261,4 +276,22 @@ export function generateROSAptPackageNames(
 		}
 	}
 	return rosAptPackageNames;
+}
+
+export function checkForROSGzVendorPackages(
+	gazeboDistro: string,
+	rosGzDistrosList: string[],
+): boolean {
+	for (const rosDistro of rosGzDistrosList) {
+		const distroInfo = validROSGzDistrosList.find(
+			(distro) => distro.rosDistro === rosDistro,
+		);
+		if (
+			distroInfo!.vendorPackagesAvailable &&
+			distroInfo!.officialROSGzWrappers.indexOf(gazeboDistro) > -1
+		) {
+			return true;
+		}
+	}
+	return false;
 }


### PR DESCRIPTION
Closes #79

## Summary

This PR introduces a check against the input list of ROS 2 distributions before installing Gazebo. In case of availability of packages as vendor installation, `ros_gz` is installed instead of Gazebo.