### PR TITLE
Fixed tests and removed Garden jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,9 +148,9 @@ jobs:
 
           # Gazebo Ionic (Sep 2024 - Sep 2026)
           # Compatible ubuntu distributions: 24.04
-          - ubuntu_distribution: ubuntu:focal
+          - docker_image: ubuntu:focal
             gazebo_distribution: ionic
-          - ubuntu_distribution: ubuntu:jammy
+          - docker_image: ubuntu:jammy
             gazebo_distribution: ionic
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,8 @@ jobs:
         gazebo_distribution:
           - citadel
           - fortress
-          - garden
           - harmonic
+          - ionic
         exclude:
           # Gazebo Citadel (Dec 2019 - Dec 2024)
           # Compatible ubuntu distributions: 20.04
@@ -78,17 +78,17 @@ jobs:
           - ubuntu_distribution: ubuntu-24.04
             gazebo_distribution: fortress
 
-          # Gazebo Garden (Sep 2022 - Nov 2024)
-          # Compatible ubuntu distributions: 20.04
-          - ubuntu_distribution: ubuntu-22.04
-            gazebo_distribution: garden
-          - ubuntu_distribution: ubuntu-24.04
-            gazebo_distribution: garden
-
           # Gazebo Harmonic (Sep 2023 - Sep 2028)
           # Compatible ubuntu distributions: 22.04, 24.04
           - ubuntu_distribution: ubuntu-20.04
             gazebo_distribution: harmonic
+
+          # Gazebo Ionic (Sep 2024 - Sep 2026)
+          # Compatible ubuntu distributions: 24.04
+          - ubuntu_distribution: ubuntu-20.04
+            gazebo_distribution: ionic
+          - ubuntu_distribution: ubuntu-22.04
+            gazebo_distribution: ionic
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.4
@@ -124,8 +124,8 @@ jobs:
         gazebo_distribution:
           - citadel
           - fortress
-          - garden
           - harmonic
+          - ionic
         exclude:
           # Gazebo Citadel (Dec 2019 - Dec 2024)
           # Compatible ubuntu docker images: focal
@@ -141,17 +141,17 @@ jobs:
           - docker_image: ubuntu:noble
             gazebo_distribution: fortress
 
-          # Gazebo Garden (Sep 2022 - Nov 2024)
-          # Compatible ubuntu docker images: focal
-          - docker_image: ubuntu:jammy
-            gazebo_distribution: garden
-          - docker_image: ubuntu:noble
-            gazebo_distribution: garden
-
           # Gazebo Harmonic (Sep 2023 - Sep 2028)
           # Compatible ubuntu docker images: jammy, noble
           - docker_image: ubuntu:focal
             gazebo_distribution: harmonic
+
+          # Gazebo Ionic (Sep 2024 - Sep 2026)
+          # Compatible ubuntu distributions: 24.04
+          - ubuntu_distribution: ubuntu:focal
+            gazebo_distribution: ionic
+          - ubuntu_distribution: ubuntu:jammy
+            gazebo_distribution: ionic
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.4

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -83,10 +83,9 @@ describe("validate Gazebo distribution test", () => {
 	it("test valid distro", async () => {
 		await expect(utils.validateDistro(["citadel"])).resolves.not.toThrow();
 		await expect(utils.validateDistro(["fortress"])).resolves.not.toThrow();
-		await expect(utils.validateDistro(["garden"])).resolves.not.toThrow();
 		await expect(utils.validateDistro(["harmonic"])).resolves.not.toThrow();
 		await expect(
-			utils.validateDistro(["fortress", "garden"]),
+			utils.validateDistro(["fortress", "harmonic"]),
 		).resolves.not.toThrow();
 	});
 	it("test invalid distro", async () => {
@@ -94,6 +93,7 @@ describe("validate Gazebo distribution test", () => {
 		await expect(utils.validateDistro(["blueprint"])).rejects.toThrow();
 		await expect(utils.validateDistro(["dome"])).rejects.toThrow();
 		await expect(utils.validateDistro(["edifice"])).rejects.toThrow();
+		await expect(utils.validateDistro(["garden"])).rejects.toThrow();
 		await expect(utils.validateDistro(["doesNotExist"])).rejects.toThrow();
 		await expect(utils.validateDistro(["dome", "fortress"])).rejects.toThrow();
 		await expect(
@@ -189,13 +189,8 @@ describe("generate APT package names for ros_gz", () => {
 			utils.generateROSGzAptPackageNames(["humble"], ["fortress"]),
 		).toEqual(["gz-fortress", "ros-humble-ros-gz"]);
 		await expect(
-			utils.generateROSGzAptPackageNames(["iron"], ["fortress", "garden"]),
-		).toEqual([
-			"gz-fortress",
-			"ros-iron-ros-gz",
-			"gz-garden",
-			"ros-iron-ros-gzgarden",
-		]);
+			utils.generateROSGzAptPackageNames(["iron"], ["fortress"]),
+		).toEqual(["gz-fortress", "ros-iron-ros-gz"]);
 		await expect(
 			utils.generateROSGzAptPackageNames(["jazzy"], ["harmonic"]),
 		).toEqual(["ros-jazzy-ros-gz"]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -26641,10 +26641,6 @@ const conda = __importStar(__nccwpck_require__(7725));
 // List of mapped Gazebo distro to gz-sim versions
 const validLibVersions = [
     {
-        distro: "garden",
-        libVersion: 7,
-    },
-    {
         distro: "harmonic",
         libVersion: 8,
     },
@@ -26819,13 +26815,13 @@ const validROSGzDistrosList = [
     {
         rosDistro: "humble",
         officialROSGzWrappers: ["fortress"],
-        unofficialROSGzWrappers: ["garden", "harmonic"],
+        unofficialROSGzWrappers: ["harmonic"],
         vendorPackagesAvailable: false,
     },
     {
         rosDistro: "iron",
         officialROSGzWrappers: ["fortress"],
-        unofficialROSGzWrappers: ["garden", "harmonic"],
+        unofficialROSGzWrappers: ["harmonic"],
         vendorPackagesAvailable: false,
     },
     {

--- a/src/setup-gazebo-windows.ts
+++ b/src/setup-gazebo-windows.ts
@@ -4,10 +4,6 @@ import * as conda from "./package_manager/conda";
 // List of mapped Gazebo distro to gz-sim versions
 const validLibVersions: { distro: string; libVersion: number }[] = [
 	{
-		distro: "garden",
-		libVersion: 7,
-	},
-	{
 		distro: "harmonic",
 		libVersion: 8,
 	},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,13 +19,13 @@ const validROSGzDistrosList: {
 	{
 		rosDistro: "humble",
 		officialROSGzWrappers: ["fortress"],
-		unofficialROSGzWrappers: ["garden", "harmonic"],
+		unofficialROSGzWrappers: ["harmonic"],
 		vendorPackagesAvailable: false,
 	},
 	{
 		rosDistro: "iron",
 		officialROSGzWrappers: ["fortress"],
-		unofficialROSGzWrappers: ["garden", "harmonic"],
+		unofficialROSGzWrappers: ["harmonic"],
 		vendorPackagesAvailable: false,
 	},
 	{


### PR DESCRIPTION
## Summary

Since Garden is officially EOL and has been officially dropped from [gz-collections](https://raw.githubusercontent.com/gazebo-tooling/release-tools/master/jenkins-scripts/dsl/gz-collections.yaml) it is causing some unit test and a workflow jobs to fail. This PR fixes the unit tests and removes `garden` from workflows and replaces it with `ionic` jobs.