### PR TITLE
Remove 20.04 support in testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_distribution:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
     steps:
@@ -38,7 +37,6 @@ jobs:
       fail-fast: false
       matrix:
         docker_image:
-          - ubuntu:focal
           - ubuntu:jammy
           - ubuntu:noble
     steps:
@@ -55,7 +53,6 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_distribution:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
         gazebo_distribution:
@@ -64,21 +61,12 @@ jobs:
           - ionic
         exclude:
           # Gazebo Fortress (Sep 2021 - Sep 2026)
-          # Compatible ubuntu distributions: 20.04
-          - ubuntu_distribution: ubuntu-22.04
-            gazebo_distribution: fortress
+          # Compatible ubuntu distributions: 22.04
           - ubuntu_distribution: ubuntu-24.04
             gazebo_distribution: fortress
 
-          # Gazebo Harmonic (Sep 2023 - Sep 2028)
-          # Compatible ubuntu distributions: 22.04, 24.04
-          - ubuntu_distribution: ubuntu-20.04
-            gazebo_distribution: harmonic
-
           # Gazebo Ionic (Sep 2024 - Sep 2026)
           # Compatible ubuntu distributions: 24.04
-          - ubuntu_distribution: ubuntu-20.04
-            gazebo_distribution: ionic
           - ubuntu_distribution: ubuntu-22.04
             gazebo_distribution: ionic
     steps:
@@ -110,7 +98,6 @@ jobs:
       fail-fast: false
       matrix:
         docker_image:
-          - ubuntu:focal
           - ubuntu:jammy
           - ubuntu:noble
         gazebo_distribution:
@@ -119,21 +106,12 @@ jobs:
           - ionic
         exclude:
           # Gazebo Fortress (Sep 2021 - Sep 2026)
-          # Compatible ubuntu docker images: focal
+          # Compatible ubuntu docker images: jammy
           - docker_image: ubuntu:jammy
-            gazebo_distribution: fortress
-          - docker_image: ubuntu:noble
-            gazebo_distribution: fortress
-
-          # Gazebo Harmonic (Sep 2023 - Sep 2028)
-          # Compatible ubuntu docker images: jammy, noble
-          - docker_image: ubuntu:focal
-            gazebo_distribution: harmonic
+            gazebo_distribution: fortress          
 
           # Gazebo Ionic (Sep 2024 - Sep 2026)
-          # Compatible ubuntu distributions: 24.04
-          - docker_image: ubuntu:focal
-            gazebo_distribution: ionic
+          # Compatible ubuntu distributions: 24.04          
           - docker_image: ubuntu:jammy
             gazebo_distribution: ionic
     steps:


### PR DESCRIPTION
20.04 is reaching the EOL in June, github actions warnings are starting these days.